### PR TITLE
Limit GitHub Actions token permissions

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -1,5 +1,7 @@
 name: Build and deploy
 
+permissions: read-all
+
 on:
   push:
     branches:


### PR DESCRIPTION
This is the result of scanning the repository for IaC and CI/CD vulnerabilities with [checkov](https://checkov.io)

Testing out whether such a tool could make sense to add as a standard.
