### PR TITLE
Simplify authentication.

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -20,7 +20,7 @@ watch(isLoading, async (loading) => {
       <router-link to="/search">Search</router-link>
     </nav>
     <main class="overflow-scroll">
-      <router-view v-if="!isLoading" />
+      <router-view v-if="isAuthenticated" />
     </main>
   </div>
 </template>

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,24 +1,13 @@
 <script setup lang="ts">
 import { useAuth0 } from "@auth0/auth0-vue";
 import { watch } from "vue";
-import useStore from "./composables/useStore";
 
 // logout
-const {
-  getAccessTokenSilently,
-  isLoading,
-  loginWithRedirect,
-  isAuthenticated,
-} = useAuth0();
-const { store } = useStore();
-
+const { isLoading, loginWithRedirect, isAuthenticated } = useAuth0();
 watch(isLoading, async (loading) => {
   if (loading) return;
   if (!isAuthenticated.value) {
     await loginWithRedirect();
-  } else {
-    const token = await getAccessTokenSilently();
-    store.authenticated(token);
   }
 });
 
@@ -26,14 +15,16 @@ watch(isLoading, async (loading) => {
 </script>
 
 <template>
-  <nav>
-    <router-link to="/">Home</router-link>
-    <router-link to="/browse">Browse</router-link>
-    <router-link to="/search">Search</router-link>
-  </nav>
-  <main>
-    <router-view />
-  </main>
+  <div class="flex">
+    <nav>
+      <router-link to="/">Home</router-link>
+      <router-link to="/browse">Browse</router-link>
+      <router-link to="/search">Search</router-link>
+    </nav>
+    <main class="overflow-scroll">
+      <router-view v-if="!isLoading" />
+    </main>
+  </div>
 </template>
 
 <style scoped>

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -1,0 +1,57 @@
+import { useAuth0 } from "@auth0/auth0-vue"
+import { BaseAPI, Configuration, Middleware } from "@bcc-code/bmm-sdk-fetch"
+
+export type Token = {
+    type: "bearer"
+    value: string
+}
+
+type TokenFactory = () => Promise<Token | null>
+
+export class Client {
+    constructor(tokenFactory: TokenFactory) {
+        this.middleware = {
+            pre: async (ctx) => {
+                const token = await tokenFactory()
+                const headers = new Headers(ctx.init.headers)
+
+                let authHeader: string | null= null
+                if (token) {
+                    switch (token.type) {
+                        case "bearer":
+                            authHeader = "Bearer " + token.value
+                    }
+                }
+                if (authHeader) {
+                    headers.set("Authorization", authHeader)
+                }
+
+                ctx.init.headers = headers
+
+                return ctx
+            }
+        }
+    }
+
+    private middleware: Middleware
+
+    public attach<T extends BaseAPI>(api: {
+        new (configuration: Configuration): T
+    }) {
+        return new api(new Configuration({
+            middleware: [this.middleware]
+        }))
+    }
+}
+
+export default new Client(async () => {
+    const { getAccessTokenSilently, isAuthenticated } = useAuth0()
+    if (!isAuthenticated.value) {
+        return null
+    }
+    const token = await getAccessTokenSilently()
+    return {
+        type: "bearer",
+        value: token
+    }
+})

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -22,10 +22,8 @@ export class Client {
 
   private middleware: Middleware;
 
-  public attach<T extends BaseAPI>(api: {
-    new (configuration: Configuration): T;
-  }) {
-    return new api(
+  public use<T extends BaseAPI>(Api: new (configuration: Configuration) => T) {
+    return new Api(
       new Configuration({
         middleware: [this.middleware],
       })
@@ -38,5 +36,5 @@ export default new Client(async () => {
   if (!isAuthenticated.value) {
     return null;
   }
-  return await getAccessTokenSilently();
+  return getAccessTokenSilently();
 });

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -1,12 +1,7 @@
 import { useAuth0 } from "@auth0/auth0-vue";
 import { BaseAPI, Configuration, Middleware } from "@bcc-code/bmm-sdk-fetch";
 
-export interface Token {
-  type: "bearer";
-  value: string;
-}
-
-type TokenFactory = () => Promise<Token | null>;
+type TokenFactory = () => Promise<string | null>;
 
 export class Client {
   constructor(tokenFactory: TokenFactory) {
@@ -14,8 +9,8 @@ export class Client {
       pre: async (ctx) => {
         const token = await tokenFactory();
         const headers = new Headers(ctx.init.headers);
-        if (token && token.type === "bearer") {
-          headers.set("Authorization", `Bearer ${token.value}`);
+        if (token) {
+          headers.set("Authorization", `Bearer ${token}`);
         }
 
         ctx.init.headers = headers;
@@ -43,9 +38,5 @@ export default new Client(async () => {
   if (!isAuthenticated.value) {
     return null;
   }
-  const token = await getAccessTokenSilently();
-  return {
-    type: "bearer",
-    value: token,
-  };
+  return await getAccessTokenSilently();
 });

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -1,57 +1,62 @@
-import { useAuth0 } from "@auth0/auth0-vue"
-import { BaseAPI, Configuration, Middleware } from "@bcc-code/bmm-sdk-fetch"
+import { useAuth0 } from "@auth0/auth0-vue";
+import { BaseAPI, Configuration, Middleware } from "@bcc-code/bmm-sdk-fetch";
 
-export type Token = {
-    type: "bearer"
-    value: string
-}
+export interface Token {
+  type: "bearer";
+  value: string;
+};
 
-type TokenFactory = () => Promise<Token | null>
+type TokenFactory = () => Promise<Token | null>;
 
 export class Client {
-    constructor(tokenFactory: TokenFactory) {
-        this.middleware = {
-            pre: async (ctx) => {
-                const token = await tokenFactory()
-                const headers = new Headers(ctx.init.headers)
+  constructor(tokenFactory: TokenFactory) {
+    this.middleware = {
+      pre: async (ctx) => {
+        const token = await tokenFactory();
+        const headers = new Headers(ctx.init.headers);
 
-                let authHeader: string | null= null
-                if (token) {
-                    switch (token.type) {
-                        case "bearer":
-                            authHeader = "Bearer " + token.value
-                    }
-                }
-                if (authHeader) {
-                    headers.set("Authorization", authHeader)
-                }
-
-                ctx.init.headers = headers
-
-                return ctx
-            }
+        let authHeader: string | null = null;
+        if (token) {
+          switch (token.type) {
+            case "bearer":
+              authHeader = "Bearer " + token.value;
+              break;
+            default:
+              break;
+          }
         }
-    }
+        if (authHeader) {
+          headers.set("Authorization", authHeader);
+        }
 
-    private middleware: Middleware
+        ctx.init.headers = headers;
 
-    public attach<T extends BaseAPI>(api: {
-        new (configuration: Configuration): T
-    }) {
-        return new api(new Configuration({
-            middleware: [this.middleware]
-        }))
-    }
+        return ctx;
+      },
+    };
+  }
+
+  private middleware: Middleware;
+
+  public attach<T extends BaseAPI>(api: {
+    new (configuration: Configuration): T;
+  }) {
+    return new api(
+      new Configuration({
+        middleware: [this.middleware],
+      })
+    );
+  }
 }
 
 export default new Client(async () => {
-    const { getAccessTokenSilently, isAuthenticated } = useAuth0()
-    if (!isAuthenticated.value) {
-        return null
-    }
-    const token = await getAccessTokenSilently()
-    return {
-        type: "bearer",
-        value: token
-    }
-})
+  const { getAccessTokenSilently, isAuthenticated } = useAuth0();
+  if (!isAuthenticated.value) {
+    return null;
+  }
+  const token = await getAccessTokenSilently();
+  return {
+    type: "bearer",
+    value: token,
+  };
+});

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -4,7 +4,7 @@ import { BaseAPI, Configuration, Middleware } from "@bcc-code/bmm-sdk-fetch";
 export interface Token {
   type: "bearer";
   value: string;
-};
+}
 
 type TokenFactory = () => Promise<Token | null>;
 
@@ -14,19 +14,8 @@ export class Client {
       pre: async (ctx) => {
         const token = await tokenFactory();
         const headers = new Headers(ctx.init.headers);
-
-        let authHeader: string | null = null;
-        if (token) {
-          switch (token.type) {
-            case "bearer":
-              authHeader = "Bearer " + token.value;
-              break;
-            default:
-              break;
-          }
-        }
-        if (authHeader) {
-          headers.set("Authorization", authHeader);
+        if (token && token.type === "bearer") {
+          headers.set("Authorization", `Bearer ${token.value}`);
         }
 
         ctx.init.headers = headers;

--- a/src/api/playlists.ts
+++ b/src/api/playlists.ts
@@ -1,0 +1,38 @@
+import { useAuth0 } from "@auth0/auth0-vue";
+import {
+  Configuration,
+  PlaylistApi,
+  PlaylistModel,
+} from "@bcc-code/bmm-sdk-fetch";
+
+export const list = async () => {
+  const { getAccessTokenSilently } = useAuth0();
+
+  const token = await getAccessTokenSilently()
+
+  return new PlaylistApi(
+    new Configuration({
+      basePath: import.meta.env.VITE_API_URL,
+      headers: {
+        Authorization: `Bearer ${token}`,
+        "Accept-Language": "nb,en,zxx",
+      },
+    })
+  ).playlistGet();
+};
+
+export const get = async (id: NonNullable<PlaylistModel["id"]>) => {
+  const { getAccessTokenSilently } = useAuth0();
+
+  const token = await getAccessTokenSilently()
+
+  return new PlaylistApi(
+    new Configuration({
+      basePath: import.meta.env.VITE_API_URL,
+      headers: {
+        Authorization: `Bearer ${token}`,
+        "Accept-Language": "nb,en,zxx",
+      },
+    })
+  ).playlistIdGet({ id });
+};

--- a/src/api/playlists.ts
+++ b/src/api/playlists.ts
@@ -1,38 +1,13 @@
-import { useAuth0 } from "@auth0/auth0-vue";
 import {
-  Configuration,
   PlaylistApi,
   PlaylistModel,
 } from "@bcc-code/bmm-sdk-fetch";
+import client from "./client";
 
 export const list = async () => {
-  const { getAccessTokenSilently } = useAuth0();
-
-  const token = await getAccessTokenSilently();
-
-  return new PlaylistApi(
-    new Configuration({
-      basePath: import.meta.env.VITE_API_URL,
-      headers: {
-        Authorization: `Bearer ${token}`,
-        "Accept-Language": "nb,en,zxx",
-      },
-    })
-  ).playlistGet();
+  return client.attach(PlaylistApi).playlistGet();
 };
 
 export const get = async (id: NonNullable<PlaylistModel["id"]>) => {
-  const { getAccessTokenSilently } = useAuth0();
-
-  const token = await getAccessTokenSilently();
-
-  return new PlaylistApi(
-    new Configuration({
-      basePath: import.meta.env.VITE_API_URL,
-      headers: {
-        Authorization: `Bearer ${token}`,
-        "Accept-Language": "nb,en,zxx",
-      },
-    })
-  ).playlistIdGet({ id });
+  return client.attach(PlaylistApi).playlistIdGet({ id });
 };

--- a/src/api/playlists.ts
+++ b/src/api/playlists.ts
@@ -1,13 +1,7 @@
-import {
-  PlaylistApi,
-  PlaylistModel,
-} from "@bcc-code/bmm-sdk-fetch";
+import { PlaylistApi, PlaylistModel } from "@bcc-code/bmm-sdk-fetch";
 import client from "./client";
 
-export const list = async () => {
-  return client.attach(PlaylistApi).playlistGet();
-};
+export const list = async () => client.attach(PlaylistApi).playlistGet();
 
-export const get = async (id: NonNullable<PlaylistModel["id"]>) => {
-  return client.attach(PlaylistApi).playlistIdGet({ id });
-};
+export const get = async (id: NonNullable<PlaylistModel["id"]>) =>
+  client.attach(PlaylistApi).playlistIdGet({ id });

--- a/src/api/playlists.ts
+++ b/src/api/playlists.ts
@@ -8,7 +8,7 @@ import {
 export const list = async () => {
   const { getAccessTokenSilently } = useAuth0();
 
-  const token = await getAccessTokenSilently()
+  const token = await getAccessTokenSilently();
 
   return new PlaylistApi(
     new Configuration({
@@ -24,7 +24,7 @@ export const list = async () => {
 export const get = async (id: NonNullable<PlaylistModel["id"]>) => {
   const { getAccessTokenSilently } = useAuth0();
 
-  const token = await getAccessTokenSilently()
+  const token = await getAccessTokenSilently();
 
   return new PlaylistApi(
     new Configuration({

--- a/src/api/playlists.ts
+++ b/src/api/playlists.ts
@@ -1,7 +1,7 @@
 import { PlaylistApi, PlaylistModel } from "@bcc-code/bmm-sdk-fetch";
 import client from "./client";
 
-export const list = async () => client.attach(PlaylistApi).playlistGet();
+export const list = async () => client.use(PlaylistApi).playlistGet();
 
 export const get = async (id: NonNullable<PlaylistModel["id"]>) =>
-  client.attach(PlaylistApi).playlistIdGet({ id });
+  client.use(PlaylistApi).playlistIdGet({ id });

--- a/src/components/PlaylistOverview.vue
+++ b/src/components/PlaylistOverview.vue
@@ -1,28 +1,17 @@
 <script setup lang="ts">
 import filters from "@/utils/filters";
 import { ref, Ref } from "vue";
-import {
-  PlaylistApi,
-  PlaylistModel,
-  Configuration,
-} from "@bcc-code/bmm-sdk-fetch";
+import { PlaylistModel } from "@bcc-code/bmm-sdk-fetch";
+
+import { list } from "@/api/playlists";
 
 const playlists: Ref<PlaylistModel[]> = ref([]);
 
-new PlaylistApi(
-  new Configuration({
-    basePath: import.meta.env.VITE_API_URL,
-    headers: {
-      Authorization: `Bearer ${localStorage.getItem("token")}`,
-      "Accept-Language": "nb,en,zxx",
-    },
+list()
+  .then((r) => {
+    playlists.value = r;
   })
-)
-  .playlistGet()
-  .then((list) => {
-    playlists.value = list;
-  })
-  .catch(() => {});
+  .catch(/* TODO: implement error-handling */);
 </script>
 
 <template>

--- a/src/components/PlaylistOverview.vue
+++ b/src/components/PlaylistOverview.vue
@@ -11,7 +11,7 @@ list()
   .then((r) => {
     playlists.value = r;
   })
-  .catch(/* TODO: implement error-handling */);
+  .catch(() => null /* TODO: implement error-handling */);
 </script>
 
 <template>

--- a/src/composables/useStore.ts
+++ b/src/composables/useStore.ts
@@ -2,7 +2,7 @@ import Store from "@/store";
 import { inject } from "vue";
 
 export default function useStore() {
-  const store = inject("store") as Store;
+  const store: Store = inject("store")!;
   return {
     store,
     state: store.getState(),

--- a/src/router.ts
+++ b/src/router.ts
@@ -5,7 +5,7 @@ const router = createRouter({
   routes: [
     {
       path: "/",
-      component: import("@/views/HomeView.vue"),
+      component: () => import("@/views/HomeView.vue"),
     },
     {
       path: "/browse",

--- a/src/store.ts
+++ b/src/store.ts
@@ -1,10 +1,6 @@
 import { reactive, readonly } from "vue";
 
-interface IState {
-  loading: boolean;
-  authenticated: boolean;
-  token: string | null;
-}
+interface IState {}
 
 export default class Store {
   protected state: IState;
@@ -15,11 +11,5 @@ export default class Store {
 
   public getState() {
     return readonly(this.state);
-  }
-
-  public authenticated(token: string) {
-    this.state.token = token;
-    this.state.authenticated = true;
-    localStorage.setItem("token", token);
   }
 }

--- a/src/vue.d.ts
+++ b/src/vue.d.ts
@@ -1,0 +1,5 @@
+declare module "*.vue" {
+    import type { DefineComponent } from "vue"
+    const component: DefineComponent<{}, {}, any>
+    export default component
+}

--- a/src/vue.d.ts
+++ b/src/vue.d.ts
@@ -1,3 +1,4 @@
+/* eslint-disable */
 declare module "*.vue" {
   import type { DefineComponent } from "vue";
   const component: DefineComponent<{}, {}, any>;

--- a/src/vue.d.ts
+++ b/src/vue.d.ts
@@ -1,5 +1,5 @@
 declare module "*.vue" {
-    import type { DefineComponent } from "vue"
-    const component: DefineComponent<{}, {}, any>
-    export default component
+  import type { DefineComponent } from "vue";
+  const component: DefineComponent<{}, {}, any>;
+  export default component;
 }


### PR DESCRIPTION
I see you've been storing the token in addition to using the library, although the auth0 sdk handles this internally, so there's no reason to add additional logic. 

Here's an example of how you could avoid loading the application after auth0 has initialized.

The BMM API SDK should probably also handle the authentication flow internally (perhaps accept an async "token factory" on instantiating the client), so the requests are simplified. In src/api/client I have a proposed solution to simplify using the generated models from the sdk.