### PR TITLE
Remove vite plugins for eslint and stylelint

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,8 +49,6 @@
     "tailwindcss": "^3.2.7",
     "typescript": "^4.9.3",
     "vite": "^4.0.0",
-    "vite-plugin-eslint2": "^3.2.1",
-    "vite-plugin-stylelint": "^4.2.0",
     "vitest": "^0.29.2",
     "vue-tsc": "^1.0.11"
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -31,8 +31,6 @@ specifiers:
   tailwindcss: ^3.2.7
   typescript: ^4.9.3
   vite: ^4.0.0
-  vite-plugin-eslint2: ^3.2.1
-  vite-plugin-stylelint: ^4.2.0
   vitest: ^0.29.2
   vue: ^3.2.45
   vue-router: ^4.1.6
@@ -73,8 +71,6 @@ devDependencies:
   tailwindcss: 3.2.7_postcss@8.4.21
   typescript: 4.9.5
   vite: 4.1.1_@types+node@18.14.0
-  vite-plugin-eslint2: 3.2.1_vxv7ci7cv7gybxz4w6v6ez4v3q
-  vite-plugin-stylelint: 4.2.0_gmulkhpbu4jrt2bk2yjxotogzq
   vitest: 0.29.2_happy-dom@8.9.0
   vue-tsc: 1.0.24_typescript@4.9.5
 
@@ -455,20 +451,6 @@ packages:
     dependencies:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.15.0
-    dev: true
-
-  /@rollup/pluginutils/5.0.2:
-    resolution: {integrity: sha512-pTd9rIsP92h+B6wWwFbW8RkZv4hiR/xKsqre4SIuAOaOEQRxi0lqLke9k2/7WegC85GgUs9pjmOjCUi3In4vwA==}
-    engines: {node: '>=14.0.0'}
-    peerDependencies:
-      rollup: ^1.20.0||^2.0.0||^3.0.0
-    peerDependenciesMeta:
-      rollup:
-        optional: true
-    dependencies:
-      '@types/estree': 1.0.0
-      estree-walker: 2.0.2
-      picomatch: 2.3.1
     dev: true
 
   /@types/chai-subset/1.3.3:
@@ -3894,47 +3876,6 @@ packages:
       - sugarss
       - supports-color
       - terser
-    dev: true
-
-  /vite-plugin-eslint2/3.2.1_vxv7ci7cv7gybxz4w6v6ez4v3q:
-    resolution: {integrity: sha512-DfhEvLGLF5/7CaMbcTeIIFl/3BfSL0nokpC1StcfKXOULAYadSxP0Vc2w3VPCEm+gpLgo9YRxETGRmRPnyA5aA==}
-    engines: {node: '>=14.18'}
-    peerDependencies:
-      '@types/eslint': ^7.0.0 || ^8.0.0
-      eslint: ^7.0.0 || ^8.0.0
-      vite: ^2.0.0 || ^3.0.0 || ^4.0.0
-    dependencies:
-      '@rollup/pluginutils': 5.0.2
-      '@types/eslint': 8.21.1
-      chokidar: 3.5.3
-      eslint: 8.34.0
-      vite: 4.1.1_@types+node@18.14.0
-    transitivePeerDependencies:
-      - rollup
-    dev: true
-
-  /vite-plugin-stylelint/4.2.0_gmulkhpbu4jrt2bk2yjxotogzq:
-    resolution: {integrity: sha512-hzy/cAwj9qlQTqV7nuucEDL3663ECQbSFrQbGcf9arXRF4ZZeJY0o/ztugEtjMdlD581BgYR+q4dEnwv5QhCxQ==}
-    engines: {node: '>=14.18'}
-    peerDependencies:
-      '@types/stylelint': ^13.0.0
-      postcss: ^7.0.0 || ^8.0.0
-      rollup: ^2.0.0 || ^3.0.0
-      stylelint: ^13.0.0 || ^14.0.0 || ^15.0.0
-      vite: ^2.0.0 || ^3.0.0 || ^4.0.0
-    peerDependenciesMeta:
-      '@types/stylelint':
-        optional: true
-      postcss:
-        optional: true
-      rollup:
-        optional: true
-    dependencies:
-      '@rollup/pluginutils': 5.0.2
-      chokidar: 3.5.3
-      postcss: 8.4.21
-      stylelint: 15.1.0
-      vite: 4.1.1_@types+node@18.14.0
     dev: true
 
   /vite/4.1.1_@types+node@18.14.0:

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,13 +1,11 @@
 /* eslint-disable import/no-extraneous-dependencies */
 import { fileURLToPath } from "url";
 import { defineConfig } from "vite";
-import eslint from "vite-plugin-eslint2";
-import stylelint from "vite-plugin-stylelint";
 import vue from "@vitejs/plugin-vue";
 
 // https://vitejs.dev/config/
 export default defineConfig({
-  plugins: [eslint({}), stylelint({}), vue()],
+  plugins: [vue()],
   server: {
     port: 9001,
   },


### PR DESCRIPTION
As types (typescript) are not checked either, it would be weird to have them in but not typescript. The vite team has deliberately left it out and its better to remain consistent here (https://vitejs.dev/guide/features.html#transpile-only).

Another option, which is also provided on the vites website is to introduce type-checking on change. For me, the argument, that the code editor should take care of that is a perfectly valid argument, which also applies to all the eslint and stylelint rules as well. If they're not explicitly getting the code to fail, this is a better way.

For everyone who doesn't have a such rich editor, he is always free to use VSCode, for which this project has a preset for, or run the package-command `lint` once in a while. The commands there can also be each extracted and ran in a watch-mode if desired, for which I haven't taken the time for.