### PR TITLE
Moved uploading of codecov files to main task

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -27,6 +27,8 @@ jobs:
         run: pnpm lint
       - name: Test and create coverage
         run: pnpm coverage
+      - name: Upload coverage reports to Codecov
+        uses: codecov/codecov-action@v3
       - name: Build for production
         run: pnpm build:prod
 
@@ -40,17 +42,6 @@ jobs:
         with:
           name: code-coverage-report
           path: coverage
-
-  upload_code_coverage:
-    runs-on: ubuntu-latest
-    needs: build_and_test
-    steps:
-      - name: Download code coverage reports
-        uses: actions/download-artifact@v3
-        with:
-          name: code-coverage-report
-      - name: Upload coverage reports to Codecov
-        uses: codecov/codecov-action@v3
 
   deploy_azure_static_web_apps:
     runs-on: ubuntu-latest


### PR DESCRIPTION
It seems that codecov needs the code alongside with the coverage report. Previously those tasks were split because we saw the azure-upload failing, which shouldn't happen to codecov as the action doesn't get the task to fail if the upload fails (see https://github.com/codecov/codecov-action#arguments - fail_ci_if_error)