### PR TITLE
Update sdk

### DIFF
--- a/components/ProtectedImage.vue
+++ b/components/ProtectedImage.vue
@@ -7,7 +7,7 @@ const props = defineProps<{
   alt?: string;
 }>();
 
-const source = ref<string>();
+const source = ref<string>("");
 const { getAccessTokenSilently } = useAuth0();
 
 watch(
@@ -20,5 +20,5 @@ watch(
 );
 </script>
 <template>
-  <img :src="source || ''" :alt="alt || ''" loading="lazy" v-bind="$attrs" />
+  <img :src="source" :alt="alt || ''" loading="lazy" v-bind="$attrs" />
 </template>

--- a/components/playlist/PlaylistCarousel.vue
+++ b/components/playlist/PlaylistCarousel.vue
@@ -10,8 +10,8 @@ defineProps<{
   <div class="flex h-64 w-full gap-6 overflow-x-auto">
     <NuxtLink
       v-for="playlist in playlists"
-      :key="playlist.id || 0"
-      :to="{ name: 'playlist-curated-id', params: { id: playlist.id || 0 } }"
+      :key="playlist.id"
+      :to="{ name: 'playlist-curated-id', params: { id: playlist.id } }"
       class="aspect-square h-full"
     >
       <ProtectedImage

--- a/components/playlist/PlaylistOverview.spec.ts
+++ b/components/playlist/PlaylistOverview.spec.ts
@@ -19,14 +19,17 @@ describe("component PlaylistOverview", async () => {
       Promise.resolve([
         {
           id: 10,
+          type: "playlist",
           title: "TestSamplePlaylist1",
         },
         {
           id: 12,
+          type: "playlist",
           title: "TestSamplePlaylist2",
         },
         {
           id: 11,
+          type: "playlist",
           title: "TestSamplePlaylist3",
         },
       ])

--- a/components/playlist/PlaylistOverview.vue
+++ b/components/playlist/PlaylistOverview.vue
@@ -11,8 +11,8 @@ defineProps<{
   <div class="grid grid-cols-4 gap-8">
     <NuxtLink
       v-for="playlist in playlists"
-      :key="playlist.id || 0"
-      :to="{ name: 'playlist-curated-id', params: { id: playlist.id || 0 } }"
+      :key="playlist.id"
+      :to="{ name: 'playlist-curated-id', params: { id: playlist.id } }"
     >
       <PlaylistCard :playlist="playlist" />
     </NuxtLink>

--- a/components/sidebar/SidebarElement.vue
+++ b/components/sidebar/SidebarElement.vue
@@ -33,11 +33,11 @@ const { data: collections } = useTrackCollections();
       <SidebarGroup title="Playlists">
         <SidebarItem
           v-for="collection in collections"
-          :key="collection.id || 0"
+          :key="collection.id"
           :title="collection.name || ''"
           :link="{
             name: 'playlist-private-id',
-            params: { id: collection.id || 0 },
+            params: { id: collection.id },
           }"
         />
       </SidebarGroup>

--- a/components/track/TrackList.vue
+++ b/components/track/TrackList.vue
@@ -84,7 +84,7 @@ const dropdownMenuItemsForTrack = (track: TrackModel) => {
     <template v-else>
       <TrackItem
         v-for="(track, i) in tracks"
-        :key="track.id || 0"
+        :key="track.id"
         :track="track"
         show-thumbnail
         @play-track="setCurrentTrack(track)"

--- a/composables/album.ts
+++ b/composables/album.ts
@@ -10,7 +10,7 @@ interface UseAlbumOptions {
 export function useAlbum(options: UseAlbumOptions) {
   const { id } = options;
 
-  return useAsyncData<AlbumModel>(`album-${id}`, () =>
+  return useLazyAsyncData<AlbumModel>(`album-${id}`, () =>
     new AlbumApi().albumIdGet({ id })
   );
 }
@@ -19,5 +19,7 @@ export function useAlbum(options: UseAlbumOptions) {
  * Get all albums
  */
 export function useAlbums() {
-  return useAsyncData<AlbumModel[]>("albums", () => new AlbumApi().albumGet());
+  return useLazyAsyncData<AlbumModel[]>("albums", () =>
+    new AlbumApi().albumGet()
+  );
 }

--- a/composables/playlist.ts
+++ b/composables/playlist.ts
@@ -14,7 +14,7 @@ interface UsePlaylistOptions {
 export function usePlaylist(options: UsePlaylistOptions) {
   const { id } = options;
 
-  return useAsyncData<PlaylistModel>(`playlist-${id}`, () =>
+  return useLazyAsyncData<PlaylistModel>(`playlist-${id}`, () =>
     new PlaylistApi().playlistIdGet({ id })
   );
 }
@@ -29,7 +29,7 @@ interface UsePlaylistTracksOptions {
 export function usePlaylistTracks(options: UsePlaylistTracksOptions) {
   const { id } = options;
 
-  return useAsyncData<TrackModel[]>(`playlist-tracks-${id}`, () =>
+  return useLazyAsyncData<TrackModel[]>(`playlist-tracks-${id}`, () =>
     new PlaylistApi().playlistIdTrackGet({ id })
   );
 }
@@ -38,7 +38,7 @@ export function usePlaylistTracks(options: UsePlaylistTracksOptions) {
  * Get all curated playlists
  */
 export function usePlaylists() {
-  return useAsyncData<PlaylistModel[]>("playlists", () =>
+  return useLazyAsyncData<PlaylistModel[]>("playlists", () =>
     new PlaylistApi().playlistGet()
   );
 }

--- a/composables/track.ts
+++ b/composables/track.ts
@@ -1,7 +1,7 @@
 import { TrackApi, TrackGetRequest, TrackModel } from "@bcc-code/bmm-sdk-fetch";
 
 export function useTracks(options: TrackGetRequest = {}) {
-  return useAsyncData<TrackModel[]>("tracks", () =>
+  return useLazyAsyncData<TrackModel[]>("tracks", () =>
     new TrackApi().trackGet(options)
   );
 }

--- a/composables/trackCollection.ts
+++ b/composables/trackCollection.ts
@@ -1,6 +1,7 @@
 import {
   GetTrackCollectionModel,
   TrackCollectionApi,
+  TrackCollectionDetails,
 } from "@bcc-code/bmm-sdk-fetch";
 
 interface UseTrackCollectionOptions {
@@ -22,7 +23,7 @@ export function useTrackCollection(options: UseTrackCollectionOptions) {
  * Get all track collections
  */
 export function useTrackCollections() {
-  return useAsyncData<GetTrackCollectionModel[]>("track-collections", () =>
+  return useAsyncData<TrackCollectionDetails[]>("track-collections", () =>
     new TrackCollectionApi().trackCollectionGet()
   );
 }

--- a/composables/trackCollection.ts
+++ b/composables/trackCollection.ts
@@ -14,8 +14,9 @@ interface UseTrackCollectionOptions {
 export function useTrackCollection(options: UseTrackCollectionOptions) {
   const { id } = options;
 
-  return useAsyncData<GetTrackCollectionModel>(`track-collection-${id}`, () =>
-    new TrackCollectionApi().trackCollectionIdGet({ id })
+  return useLazyAsyncData<GetTrackCollectionModel>(
+    `track-collection-${id}`,
+    () => new TrackCollectionApi().trackCollectionIdGet({ id })
   );
 }
 
@@ -23,7 +24,7 @@ export function useTrackCollection(options: UseTrackCollectionOptions) {
  * Get all track collections
  */
 export function useTrackCollections() {
-  return useAsyncData<TrackCollectionDetails[]>("track-collections", () =>
+  return useLazyAsyncData<TrackCollectionDetails[]>("track-collections", () =>
     new TrackCollectionApi().trackCollectionGet()
   );
 }

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   },
   "dependencies": {
     "@auth0/auth0-vue": "^2.2.0",
-    "@bcc-code/bmm-sdk-fetch": "^5.0.0",
+    "@bcc-code/bmm-sdk-fetch": "^6.1.1",
     "@pinia/nuxt": "^0.4.9",
     "class-variance-authority": "^0.5.2"
   },

--- a/pages/album/[id].vue
+++ b/pages/album/[id].vue
@@ -39,7 +39,7 @@ const toggleExpandedAlbum = (albumReference: string) => {
     <p v-if="album.children" class="p-2">{{ album.children.length }} albums</p>
     <div v-for="(child, i) in album?.children" :key="`${child.id}-${i}`">
       <AlbumSubAlbum
-        :id="child.id || 0"
+        :id="child.id"
         :active="expandedAlbum === `${child.id}-${i}`"
         @expand="toggleExpandedAlbum(`${child.id}-${i}`)"
       ></AlbumSubAlbum>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,8 +5,8 @@ dependencies:
     specifier: ^2.2.0
     version: 2.2.0
   '@bcc-code/bmm-sdk-fetch':
-    specifier: ^5.0.0
-    version: 5.0.0
+    specifier: ^6.1.1
+    version: 6.1.1
   '@pinia/nuxt':
     specifier: ^0.4.9
     version: 0.4.9(typescript@4.9.5)(vue@3.2.47)
@@ -434,8 +434,8 @@ packages:
       '@babel/helper-validator-identifier': 7.19.1
       to-fast-properties: 2.0.0
 
-  /@bcc-code/bmm-sdk-fetch@5.0.0:
-    resolution: {integrity: sha512-EcIqLS22CS6MoKy/ijscE/OApDtco7HSGnO8cIGRMXX2XPseXH09/CJN9utDOYEeC6Ru3xB38h9OSZiaEKARjA==}
+  /@bcc-code/bmm-sdk-fetch@6.1.1:
+    resolution: {integrity: sha512-0u7wWrTt8LOXgYlW0jVg4ln4zmAyrTKocMElf/CikoL58+7hizlQsIEs7oW2p/oxplGYOLX8lZEb57zP28xV7w==}
     dev: false
 
   /@bcoe/v8-coverage@0.2.3:


### PR DESCRIPTION
Also updated async-data calls to be lazy. The lazy version doesn't block the transition of routing, which makes for a better user-experience if the user does not have to remain on the old view until all data for the new route is loaded.
