### PR TITLE
Handling of links and login in electron

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,1 @@
+dist-electron

--- a/.prettierignore
+++ b/.prettierignore
@@ -6,6 +6,7 @@ node_modules
 .output
 .env
 dist
+dist-electron
 coverage
 pnpm-lock.yaml
 

--- a/app.vue
+++ b/app.vue
@@ -25,7 +25,7 @@ useHead({
       <NuxtPage />
     </NuxtLayout>
     <div v-if="!isAuthenticated">
-      You are redirected to the login page. Please wait or
+      You will be redirected to the login page. Please wait or
       <a href="#" @click="loginWithRedirect()">try again</a>.
     </div>
   </div>

--- a/app.vue
+++ b/app.vue
@@ -20,11 +20,15 @@ useHead({
 </script>
 
 <template>
-  <NuxtLayout v-if="isAuthenticated">
-    <div class="container mx-auto p-2 lg:p-5">
+  <div class="container mx-auto p-2 lg:p-5">
+    <NuxtLayout v-if="isAuthenticated">
       <NuxtPage />
+    </NuxtLayout>
+    <div v-if="!isAuthenticated">
+      You are redirected to the login page. Please wait or
+      <a href="#" @click="loginWithRedirect()">try again</a>.
     </div>
-  </NuxtLayout>
+  </div>
 </template>
 
 <style>

--- a/components/sidebar/SidebarElement.vue
+++ b/components/sidebar/SidebarElement.vue
@@ -1,4 +1,5 @@
 <script lang="ts" setup>
+import { useAuth0 } from "@auth0/auth0-vue";
 import { RoutesNamedLocations } from "~/.nuxt/typed-router/__routes";
 
 const links: {
@@ -12,6 +13,14 @@ const links: {
 ];
 
 const { data: collections } = usePrivatePlaylists();
+const auth0 = useAuth0();
+const logout = async () => {
+  try {
+    await auth0.logout({ openUrl: false });
+  } catch (e) {
+    console.error(e);
+  }
+};
 </script>
 
 <template>
@@ -32,6 +41,15 @@ const { data: collections } = usePrivatePlaylists();
           :key="`${link.link}_${i}`"
           v-bind="link"
         />
+        <a
+          @click="logout()"
+          href="#"
+          class="group flex gap-2 rounded-xl px-4 py-2"
+        >
+          <span class="transition-transform group-hover:translate-x-2">
+            Logout
+          </span>
+        </a>
       </SidebarGroup>
 
       <SidebarGroup title="Playlists">

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -76,8 +76,6 @@ app
 
       // Introduced to handle login-process in the default browser. A user usually has his login credentials already saved there.
       if (!url.startsWith(`${PRODUCTION_APP_PROTOCOL}://`)) {
-        // TODO: Maybe its good to inform the user about what will happen here ...
-        // dialog.showMessageBox(window)
         e.preventDefault();
         shell.openExternal(url).catch((error) => {
           dialog.showErrorBox(url, `${error}`);

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -12,8 +12,16 @@ protocol.registerSchemesAsPrivileged([
 ]);
 
 const navigateToUri = (window: BrowserWindow, url: string) => {
-  window.loadURL(url);
-  // TODO: Use vue-router to redirect to bmm://* link
+  window.webContents.send("route-changed", url);
+};
+
+const removeUrlOrigin = (_url: string) => {
+  const url = new URL(
+    /^https?:\/\//.test(_url)
+      ? _url
+      : `http${_url.substring(_url.indexOf("://"))}`
+  );
+  return url.href.substring(url.origin.length);
 };
 
 app
@@ -26,10 +34,9 @@ app
           net
             .request({
               method: request.method,
-              url: request.url.replace(
-                `${PRODUCTION_APP_PROTOCOL}://bmm.brunstad.org`,
-                process.env.VITE_DEV_SERVER_URL || ""
-              ),
+              url: `${process.env.VITE_DEV_SERVER_URL}${removeUrlOrigin(
+                request.url
+              )}`,
             })
             .on("response", (response) => {
               callback(response);
@@ -53,9 +60,21 @@ app
       );
     }
 
-    const window = new BrowserWindow();
-    // Forward each URL, which is not on the custom protocol, to the browser. Introduced for login-process.
+    const window = new BrowserWindow({
+      webPreferences: {
+        preload: path.join(__dirname, "preload.js"),
+      },
+    });
+
     window.webContents.on("will-navigate", (e, url) => {
+      // Some links from the API have the fixed domain `bmm.brunstad.org` on the `http(s)` protocol. Use our router instead of navigating (which means reloading the "app").
+      if (/^https?:\/\/bmm\.brunstad\.org\//.test(url)) {
+        e.preventDefault();
+        navigateToUri(window, removeUrlOrigin(url));
+        return;
+      }
+
+      // Introduced to handle login-process in the default browser. A user usually has his login credentials already saved there.
       if (!url.startsWith(`${PRODUCTION_APP_PROTOCOL}://`)) {
         // TODO: Maybe its good to inform the user about what will happen here ...
         // dialog.showMessageBox(window)
@@ -66,8 +85,13 @@ app
       }
     });
 
+    // Event is triggered when another program opens a `bmm://` link.
     app.on("open-url", (_, url) => {
-      navigateToUri(window, url);
+      if (/^bmm:\/\//.test(url)) {
+        navigateToUri(window, removeUrlOrigin(url));
+      } else {
+        window.loadURL(url);
+      }
     });
 
     return window.loadURL(`${PRODUCTION_APP_PROTOCOL}://bmm.brunstad.org`);

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -1,0 +1,7 @@
+import { ipcRenderer } from "electron";
+
+window.addEventListener("DOMContentLoaded", () => {
+  ipcRenderer.on("route-changed", (_event, url: string) => {
+    window.dispatchEvent(new CustomEvent("route-changed", { detail: url }));
+  });
+});

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -43,5 +43,12 @@ export default defineNuxtConfig({
   },
   app: {
     pageTransition: { name: "page", mode: "out-in" },
+    head: { base: { href: "/" } },
+  },
+  router: {
+    options: {
+      // Setting app.head.base changes the default for "hashMode" to "true" ...
+      hashMode: false,
+    },
   },
 });

--- a/pages/[...error].vue
+++ b/pages/[...error].vue
@@ -5,6 +5,6 @@ const { params } = useRoute<"error">();
 <template>
   <div>
     <h2>{{ $t("error.page-not-found.headline") }}</h2>
-    {{ $t("error.page-not-found.text", params) }}
+    {{ $t("error.page-not-found.text", { path: params.error.join("/") }) }}
   </div>
 </template>

--- a/plugins/3.mediaPlayer.ts
+++ b/plugins/3.mediaPlayer.ts
@@ -37,8 +37,10 @@ export default defineNuxtPlugin((nuxtApp) => {
 
   watch(
     isAuthenticated,
-    async () => {
-      authToken.value = await getAccessTokenSilently();
+    async (authenticated) => {
+      authToken.value = authenticated
+        ? await getAccessTokenSilently()
+        : undefined;
     },
     { immediate: true }
   );

--- a/plugins/updateRouterOnRouteChangeEvent.client.ts
+++ b/plugins/updateRouterOnRouteChangeEvent.client.ts
@@ -1,0 +1,19 @@
+export default defineNuxtPlugin((nuxtApp) => {
+  window.addEventListener("route-changed", (_e) => {
+    const e = _e as CustomEvent<string>;
+    navigateTo(e.detail)
+      .then(() => {
+        const { search } = window.location;
+        if (
+          (search.includes("code=") || search.includes("error=")) &&
+          search.includes("state=")
+        )
+          return nuxtApp.vueApp.config.globalProperties.$auth0.handleRedirectCallback();
+        return null;
+      })
+      .catch((err) => {
+        // TODO: How should we deal with this ..?
+        console.error("Route-changed failed", err);
+      });
+  });
+});


### PR DESCRIPTION
Did quite some changes on handling links which sum up in that links from external sources (another application opens `bmm://` links) and external links (links to `bmm.brunstad.org` via `http` or `https`) are handled by vues router.

The message shown to the user in electron while the login is in progress could do well with some styling, but I'll for now leave it up to @sclausendk to define how it should look like.

I've also added a long awaited logout link - just for having one...

Fixes #123 and #128