### PR TITLE
Media keys

### DIFF
--- a/plugins/3.mediaPlayer.ts
+++ b/plugins/3.mediaPlayer.ts
@@ -156,7 +156,7 @@ export default defineNuxtPlugin((nuxtApp) => {
     return track;
   }
 
-  nuxtApp.vueApp.provide(MediaPlayerInjectionKey, {
+  const mediaPlayer: MediaPlayer = {
     status: playerStatus,
     play: () => activeMedia?.play(),
     pause: () => activeMedia?.pause(),
@@ -164,12 +164,21 @@ export default defineNuxtPlugin((nuxtApp) => {
     previous,
     hasNext,
     hasPrevious,
-  });
+  };
+  nuxtApp.vueApp.provide(MediaPlayerInjectionKey, mediaPlayer);
 
-  nuxtApp.vueApp.provide(MediaPlaylistInjectionKey, {
+  const mediaPlaylist: MediaPlaylist = {
     currentTrack: computed(() => currentTrack.value),
     setCurrentTrack,
     clearCurrentTrack,
     addTrackToQueue,
-  });
+  };
+  nuxtApp.vueApp.provide(MediaPlaylistInjectionKey, mediaPlaylist);
+
+  return {
+    provide: {
+      mediaPlayer,
+      mediaPlaylist,
+    },
+  };
 });

--- a/plugins/4.mediaKeys.ts
+++ b/plugins/4.mediaKeys.ts
@@ -1,0 +1,79 @@
+import { defineNuxtPlugin, useNuxtApp } from "#app";
+import { MediaPlayerStatus } from "./3.mediaPlayer";
+
+export default defineNuxtPlugin(() => {
+  const { $mediaPlayer, $mediaPlaylist } = useNuxtApp();
+
+  // Register DOM Media Session, if available
+  if ("mediaSession" in navigator) {
+    watch(
+      $mediaPlaylist.currentTrack,
+      (track) => {
+        if (!track) {
+          navigator.mediaSession.metadata = null;
+          return;
+        }
+
+        const artwork: MediaImage[] = [];
+
+        if (track.cover) {
+          artwork.push({
+            src: track.cover,
+          });
+        }
+
+        navigator.mediaSession.metadata = new MediaMetadata({
+          title: track.meta?.title || "",
+          artist: track.meta?.artist || "",
+          album: track.meta?.album || "",
+          artwork,
+        });
+      },
+      { immediate: true }
+    );
+    watch(
+      $mediaPlayer.status,
+      (state) => {
+        switch (state) {
+          case MediaPlayerStatus.Paused:
+            navigator.mediaSession.playbackState = "paused";
+            break;
+          case MediaPlayerStatus.Playing:
+            navigator.mediaSession.playbackState = "playing";
+            break;
+          case MediaPlayerStatus.Stopped:
+            navigator.mediaSession.playbackState = "none";
+            break;
+          default:
+            ((_: never) => {})(state);
+        }
+      },
+      { immediate: true }
+    );
+
+    navigator.mediaSession.setActionHandler("play", () => {
+      $mediaPlayer.play();
+    });
+    navigator.mediaSession.setActionHandler("pause", () => {
+      $mediaPlayer.pause();
+    });
+    navigator.mediaSession.setActionHandler("stop", () => {
+      $mediaPlayer.pause();
+    });
+    navigator.mediaSession.setActionHandler("seekbackward", (_) => {
+      console.error("The event `seekbackward` is not implemented yet");
+    });
+    navigator.mediaSession.setActionHandler("seekforward", (_) => {
+      console.error("The event `seekforward` is not implemented yet");
+    });
+    navigator.mediaSession.setActionHandler("seekto", (_) => {
+      console.error("The event `seekto` is not implemented yet");
+    });
+    navigator.mediaSession.setActionHandler("previoustrack", () => {
+      $mediaPlayer.previous();
+    });
+    navigator.mediaSession.setActionHandler("nexttrack", () => {
+      $mediaPlayer.next();
+    });
+  }
+});


### PR DESCRIPTION
Fixes #136.

As far as I could test, registering the DOM Media Session already fixed all of our requests for handling media keys - at least on MacOS.

If needed, I'll later include the registering of the media-keys, but at least on MacOS none of them could be registered, and the DOM Media Session did the job quite well.
[electron-media-keys.patch](https://github.com/bcc-code/bmm-web/files/11892859/electron-media-keys.patch)

Because of some quirx in typescript, this PR includes #159, which should be merged first.