### PR TITLE
Infer typing ref

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ node_modules
 .env
 dist
 dist-electron
+coverage
 
 # Generated files
 tailwind.config.ts

--- a/components/track/TrackList.vue
+++ b/components/track/TrackList.vue
@@ -15,7 +15,7 @@ const props = withDefaults(
 );
 
 const { setCurrentTrack, addTrackToQueue } = inject(MediaPlaylistInjectionKey)!;
-const showDropDownForTrack: Ref<null | string> = ref(null);
+const showDropDownForTrack = ref<string | null>(null);
 
 const isTrackTypeKnown = () => {
   const firstType = props.tracks?.[0]?.subtype;

--- a/pages/album/[id].vue
+++ b/pages/album/[id].vue
@@ -7,7 +7,7 @@ const albumId = Number(id);
 
 const { data: album } = useAlbum({ id: albumId });
 
-const expandedAlbum: Ref<null | string> = ref(null);
+const expandedAlbum = ref<string | null>(null);
 
 const toggleExpandedAlbum = (albumReference: string) => {
   if (expandedAlbum.value === albumReference) {

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -9,8 +9,8 @@ const { setCurrentTrack } = inject(MediaPlaylistInjectionKey)!;
 const { t, locale } = useI18n();
 toolbarTitleStore().setReactiveToolbarTitle(() => t("nav.home"));
 
-const discoverGroups: Ref<IDiscoverableGroup[] | null> = ref(null);
-const loading: Ref<boolean> = ref(true);
+const discoverGroups = ref<IDiscoverableGroup[] | null>(null);
+const loading = ref(true);
 const { user } = useAuth0();
 
 function calculateAge(birthdate: string | undefined) {


### PR DESCRIPTION
[Typings for `ref()` can be inferred, and it's also correct to do so because those typings are not just `Ref<T>`, but `Ref<UnwrapRef<T>>`](https://vuejs.org/api/reactivity-core.html#ref), which we could import from `vue`; but it's even better to have types inferred.