### PR TITLE
Calculate package version from git in pipeline

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -31,6 +31,8 @@ jobs:
 
       - name: Install dependencies
         run: pnpm install
+      - name: Calculate package version
+        run: git fetch --unshallow && pnpm update:version
       - name: Run linters
         run: pnpm lint
       - name: Test and create coverage

--- a/.github/workflows/electron.yml
+++ b/.github/workflows/electron.yml
@@ -29,6 +29,9 @@ jobs:
       - name: Install dependencies
         run: pnpm install
 
+      - name: Calculate package version
+        run: git fetch --unshallow && pnpm update:version
+
       - name: Download certificate file
         run: |
           echo $APPLE_DEVELOPER_ID_FILE | base64 --decode >> developer-id.privatekey.p12

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "e2e": "cypress open",
     "lint": "stylelint \"**/*.{vue,scss}\" && prettier . --check && eslint --ext ts,js,vue,json . && ELECTRON=true nuxi typecheck",
     "test": "vitest",
-    "postinstall": "nuxt prepare"
+    "postinstall": "nuxt prepare",
+    "update:version": "node update-package-version.js"
   },
   "dependencies": {
     "@auth0/auth0-vue": "^2.2.0",

--- a/update-package-version.js
+++ b/update-package-version.js
@@ -1,0 +1,29 @@
+#!/usr/env node
+import { readFileSync, writeFileSync } from "fs";
+import { execSync } from "child_process";
+
+writeFileSync(
+  "package.json",
+  `${JSON.stringify(
+    {
+      ...JSON.parse(readFileSync("package.json")),
+      version: execSync("git describe --tags")
+        .toString()
+        .trim()
+        .replace(
+          /^v([0-9]+)(?:\.([0-9]+))?(?:\.([0-9]+))?(?:-([0-9]+))?(?:-g([0-9a-z]+))?.*$/,
+          (_, major, minor, patch, commitCount, objectIdentifier) =>
+            [
+              `${parseInt(major ?? "0", 10)}.${parseInt(minor ?? "0", 10)}.${
+                // Increment patch by 1 if we're not exactly at a tag.
+                // For discussion see: https://github.com/bcc-code/bmm-web/pull/185
+                parseInt(patch ?? "0", 10) + (commitCount ? 1 : 0)
+              }`,
+              ...[commitCount, objectIdentifier].filter((x) => !!x),
+            ].join("-")
+        ),
+    },
+    null,
+    2
+  )}\n`
+);


### PR DESCRIPTION
My Debian got confused when I tried to install a newer package, but the version number was the same as an older one. Then I realised that we don't track the version very well.

This is a proposed solution. It uses `git describe --tags` which outputs the tag followed by the commit count since that tag, and a short form of the last commit hash. It transforms such a value to a semver number using regex replace. For the current commit it yields `0.0.3.49`. The tag is `v0.0.3` and there have been 49 commits since that tag.

This of course will not generate unique versions cross-branches, or in case of history rewrites. I thought about using a timestamp instead. However, what I like about this method is that in general the final number is not going to be longer than 4 digits, and it is very easy for a human to see which of two versions is later.

Currently I've set it up that it only actually performs the action in the build pipelines just after the install. I have not added it to the `postinstall` because then it would run locally too. That's something we can discuss. In the pipeline it will write the version number in the `package.json`'s `version` value before the build. This ensures the version number is correctly set during e.g. electron packaging.

The actual version value in the `package.json` is not used any more except when developing locally.

To allow calculation of the version I've added `git fetch --unshallow` to the build pipeline. This is of course not ideal, and we may want to find a better way to do this, but so far I've not found it yet. `git fetch --tags` doesn't work.

Note that there's no sanity checking of the version number. If someone tags the repo with a non-conforming tag, the output of `git describe --tags` will be used unaltered. If you tag the repo with `0.0.4` instead of `v0.0.4`, and then add a commit before publishing, the deployment will use something like `0.0.4-1-gd04fc60` as version string, instead of `0.0.4.1`.