### PR TITLE
Refresh access token

### DIFF
--- a/plugins/1.auth0.client.ts
+++ b/plugins/1.auth0.client.ts
@@ -11,6 +11,7 @@ export default defineNuxtPlugin((nuxtApp) => {
       redirect_uri: window.location.origin,
       audience: runtimeConfig.public.apiUrl,
     },
+    useRefreshTokens: true,
   });
 
   nuxtApp.vueApp.use(auth0);


### PR DESCRIPTION
To solve #153

I haven't managed to test this properly yet. I tried to connect this to my own Auth0 client, to set a shorter access token time-out. That didn't work well, because that access token doesn't grant access to BMM. So you get access denied anyway.

So now I hope this PR‌ will make a build, and I can install that locally. Then I'll use that that build for a few days, to see whether it works.