### PR TITLE
Fix excessive type assertions

### DIFF
--- a/plugins/1.auth0.server.ts
+++ b/plugins/1.auth0.server.ts
@@ -1,19 +1,13 @@
-import { Auth0Plugin, AUTH0_INJECTION_KEY } from "@auth0/auth0-vue";
+import { AUTH0_INJECTION_KEY, Auth0Plugin } from "@auth0/auth0-vue";
 
-export default defineNuxtPlugin((nuxtApp) => {
-  const auth0 = {
+export default defineNuxtPlugin(({ vueApp }) => {
+  // SSR‌ doesn't really need auth0 for auth. We provide a dummy object instead.
+  // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+  const auth0Dummy = {
     getAccessTokenSilently: () => Promise.resolve(""),
     install: () => {},
-  };
-  auth0.install = () => {
-    // eslint-disable-next-line no-param-reassign
-    nuxtApp.vueApp.config.globalProperties.$auth0 =
-      auth0 as unknown as Auth0Plugin;
-    nuxtApp.vueApp.provide(
-      AUTH0_INJECTION_KEY,
-      auth0 as unknown as Auth0Plugin
-    );
-  };
-
-  nuxtApp.vueApp.use(auth0 as unknown as Auth0Plugin);
+  } as unknown as Auth0Plugin;
+  vueApp.config.globalProperties.$auth0 = auth0Dummy;
+  vueApp.provide(AUTH0_INJECTION_KEY, auth0Dummy);
+  vueApp.use(auth0Dummy);
 });


### PR DESCRIPTION
Just a minor refactor. Only assert the type once, when the object is created, instead of on every use.