### PR TITLE
Disable `no-param-reassign` for properties.

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -25,6 +25,7 @@
         "prettier"
       ],
       "rules": {
+        "no-param-reassign": ["error", { "props": false }],
         "@typescript-eslint/consistent-type-assertions": [
           "warn",
           { "assertionStyle": "never" }


### PR DESCRIPTION
The primary purpose of `no-param-reassign` is to guard the behaviour of `arguments`[^1]. Apparently one of our defaults has additionally enabled the sub-rule for argument property reassignment. I don't think it's a good fit for a Vue + Nuxt project as those APIs make it necessary in some methods. E.g. `defineNuxtPlugin` may have to modify properties of the input `nuxtApp`.

[^1]: https://eslint.org/docs/latest/rules/no-param-reassign