### PR TITLE
Fix time duration

### DIFF
--- a/components/TimeDuration.vue
+++ b/components/TimeDuration.vue
@@ -1,13 +1,16 @@
 <script setup lang="ts">
-defineProps<{
+const props = defineProps<{
   duration: number;
 }>();
+
+const timeAsText = computed(() =>
+  !Number.isFinite(props.duration)
+    ? "--:--"
+    : `${`${Math.floor(props.duration / 60)}`.padStart(2, "0")}:${`${Math.floor(
+        props.duration % 60
+      )}`.padStart(2, "0")}`
+);
 </script>
 <template>
-  <template v-if="!Number.isFinite(duration)">--:--</template>
-  <template v-else>
-    {{ (duration / 60).toFixed(0).padStart(2, "0") }}:{{
-      (duration % 60).toFixed(0).padStart(2, "0")
-    }}
-  </template>
+  {{ timeAsText }}
 </template>


### PR DESCRIPTION
The rendering of the duration on some devices was odd (getting 60 for seconds, and more complex errors like the 10th of seconds not updating properly...) but also the minutes were a rounded value, which reported 1 for 0,6 minutes.