### PR TITLE
Show error of login module

### DIFF
--- a/app.vue
+++ b/app.vue
@@ -1,7 +1,8 @@
 <script lang="ts" setup>
 import { useAuth0 } from "@auth0/auth0-vue";
 
-const { isLoading, loginWithRedirect, isAuthenticated } = useAuth0();
+const { isLoading, loginWithRedirect, isAuthenticated, error, logout } =
+  useAuth0();
 
 watch(
   isLoading,
@@ -14,6 +15,11 @@ watch(
   { immediate: true }
 );
 
+const logoutAndRedirect = async () => {
+  await logout({ openUrl: false });
+  await loginWithRedirect();
+};
+
 useHead({
   titleTemplate: (chunk) => (chunk ? `${chunk} | BMM` : "BMM"),
 });
@@ -21,12 +27,12 @@ useHead({
 
 <template>
   <div class="h-full">
-    <NuxtLayout v-if="isAuthenticated">
+    <NuxtLayout v-if="isAuthenticated && !error">
       <div class="container mx-auto p-2 lg:p-5">
         <NuxtPage />
       </div>
     </NuxtLayout>
-    <div v-if="!isAuthenticated" class="flex h-screen text-center">
+    <div v-else-if="!isAuthenticated" class="flex h-screen text-center">
       <div class="m-auto">
         <SiteLogo size="medium"></SiteLogo>
         <div>{{ $t("login.redirect-message.redirect-info") }}</div>
@@ -36,6 +42,33 @@ useHead({
             href="#"
             @click="loginWithRedirect()"
             >{{ $t("login.redirect-message.redirect-link") }}</span
+          >
+        </i18n-t>
+      </div>
+    </div>
+    <div v-else class="flex h-screen text-center">
+      <div class="m-auto">
+        <SiteLogo size="medium"></SiteLogo>
+        <div>{{ $t("login.error-message.logout-and-redirect-info") }}</div>
+        <div class="mb-5">{{ error }}</div>
+        <i18n-t
+          tag="div"
+          class="mb-5"
+          keypath="login.error-message.manual-logout-and-redirect-info"
+        >
+          <span
+            class="cursor-pointer underline"
+            href="#"
+            @click="logoutAndRedirect()"
+            >{{ $t("login.error-message.logout-and-redirect-link") }}</span
+          >
+        </i18n-t>
+        <i18n-t tag="div" keypath="login.error-message.contact-info">
+          <a
+            class="cursor-pointer underline"
+            href="mailto:bmm-support@bcc.no"
+            target="_blank"
+            >{{ $t("login.error-message.contact-link") }}</a
           >
         </i18n-t>
       </div>

--- a/locales/en.json
+++ b/locales/en.json
@@ -38,6 +38,13 @@
     "album-count": "{count} album | {count} albums"
   },
   "login": {
+    "error-message": {
+      "contact-info": "Should this error persist, {0}.",
+      "contact-link": "please get in contact with us",
+      "logout-and-redirect-info": "Something regarding the login went wrong:",
+      "manual-logout-and-redirect-info": "Please {0}.",
+      "logout-and-redirect-link": "try to log in again"
+    },
     "redirect-message": {
       "redirect-info": "You will be redirected to the login page.",
       "manual-redirect-info": "Please wait or {0}.",


### PR DESCRIPTION
Errors by the login module (like about a expiry token missing, introduced by #204), were not reported to the user but silently hidden.

This change will show the login error to the user, will give him the option to log out and try again (which is what helps for #204) or contact the support (mail address taken from the profile-menu).