### PR TITLE
Stop click-propagation of any item in track dropdown

### DIFF
--- a/components/track/TrackItem.vue
+++ b/components/track/TrackItem.vue
@@ -158,12 +158,15 @@ function secondsToTime(totalSeconds: number | undefined) {
         >
           <NuxtIcon name="queue" filled class="text-2xl" />
         </button>
-        <Menu as="div" class="relative inline-block px-2 py-0 text-left">
+        <Menu
+          as="div"
+          class="relative inline-block px-2 py-0 text-left"
+          @click.stop
+        >
           <MenuButton
             as="button"
             :aria-label="t('track.a11y.options')"
             class="relative top-0.5 rounded-lg px-2 py-0"
-            @click.stop
           >
             <NuxtIcon name="options" filled class="text-2xl" />
           </MenuButton>


### PR DESCRIPTION
Since #221, we've had the problem that a users action on a dropdown item of a track seems to be ignored. Actually, it is executed, but most of them are overwritten by the click-action of the track itself.

This PR will stop the propagation of a click action beyond the dropdown.