### PR TITLE
[Dialog] Use HeadlessUI Dialog component as base of `DialogBase` component

### DIFF
--- a/components/ChangeLocale.vue
+++ b/components/ChangeLocale.vue
@@ -1,5 +1,3 @@
-<script lang="ts" setup></script>
-
 <template>
   <select
     v-model="$i18n.locale"

--- a/components/ChangeLocale.vue
+++ b/components/ChangeLocale.vue
@@ -1,18 +1,16 @@
 <script lang="ts" setup></script>
 
 <template>
-  <div class="locale-changer">
-    <select
-      v-model="$i18n.locale"
-      class="text-black-1 dark:bg-white-1 dark:text-black-1 min-w-[100px] p-2"
+  <select
+    v-model="$i18n.locale"
+    class="text-black-1 bg-background-1 dark:bg-background-3 dark:text-black-1 min-w-[100px] pl-3 py-2.5 shadow ring-1 ring-label-separator rounded-lg"
+  >
+    <option
+      v-for="(lang, i) in $i18n.availableLocales"
+      :key="`Lang${i}`"
+      :value="lang"
     >
-      <option
-        v-for="(lang, i) in $i18n.availableLocales"
-        :key="`Lang${i}`"
-        :value="lang"
-      >
-        {{ lang }}
-      </option>
-    </select>
-  </div>
+      {{ lang }}
+    </option>
+  </select>
 </template>

--- a/components/ProfileMenu.vue
+++ b/components/ProfileMenu.vue
@@ -9,6 +9,7 @@ import {
   RadioGroup,
   RadioGroupOption,
 } from "@headlessui/vue";
+import { VueDraggable } from "vue-draggable-plus";
 
 const profileStore = useProfileStore();
 const { t } = useI18n();
@@ -206,7 +207,7 @@ const joinedContentLanguages = computed(() =>
     >
       <RadioGroup
         v-model="colorMode.preference"
-        class="bg-background-2 dark:bg-background-dark-2 rounded-2xl mt-4 font-semibold"
+        class="bg-background-2 dark:bg-background-dark-2 rounded-2xl font-semibold"
       >
         <RadioGroupOption
           v-for="mode in colorModes"
@@ -246,7 +247,39 @@ const joinedContentLanguages = computed(() =>
       :description="$t('profile.content-language-description')"
       @close="showContentLanguageDialog = false"
     >
-      <p style="background-color: rgba(255, 0, 0, 0.4)">Not implemented yet.</p>
+      <VueDraggable
+        v-model="contentLanguages"
+        handle=".handle"
+        :animation="200"
+        class="bg-background-2 dark:bg-background-dark-2 rounded-2xl font-semibold divide-y divide-label-separator"
+      >
+        <div
+          v-for="(lang, i) in contentLanguages"
+          :key="lang"
+          class="grid grid-cols-[24px_1fr_24px] items-center px-4 py-3 gap-4 w-full first:rounded-t-2xl last:rounded-b-2xl"
+        >
+          <button class="handle">
+            <svg
+              width="24"
+              height="24"
+              viewBox="0 0 24 24"
+              fill="none"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path d="M4 9H20" stroke="#ABAFB3" stroke-width="2" />
+              <path d="M4 15H20" stroke="#ABAFB3" stroke-width="2" />
+            </svg>
+          </button>
+          <div
+            class="text-black-1 bg-background-1 dark:bg-background-3 dark:text-black-1 min-w-[100px] pl-3 py-2.5 shadow ring-1 ring-label-separator rounded-lg"
+          >
+            {{ lang }}
+          </div>
+          <button v-if="i > 0" class="text-2xl">
+            <NuxtIcon name="icon.close.small" />
+          </button>
+        </div>
+      </VueDraggable>
     </DialogBase>
   </div>
 </template>

--- a/components/ProfileMenu.vue
+++ b/components/ProfileMenu.vue
@@ -231,12 +231,12 @@ const joinedContentLanguages = computed(() =>
       @close="showInterfaceLanguageDialog = false"
     >
       <div
-        class="flex content-center bg-background-2 dark:bg-background-dark-2 rounded-2xl p-3"
+        class="flex content-center gap-4 justify-between bg-background-2 dark:bg-background-dark-2 rounded-2xl p-3"
       >
         <div class="inline-block self-center">
           {{ $t("profile.select-language") }}
         </div>
-        <ChangeLocale class="mx-4" />
+        <ChangeLocale />
       </div>
     </DialogBase>
 

--- a/components/ProfileMenu.vue
+++ b/components/ProfileMenu.vue
@@ -1,6 +1,14 @@
 <script setup lang="ts">
 import { useAuth0 } from "@auth0/auth0-vue";
-import { Menu, MenuButton, MenuItem, MenuItems, Switch } from "@headlessui/vue";
+import {
+  Menu,
+  MenuButton,
+  MenuItem,
+  MenuItems,
+  Switch,
+  RadioGroup,
+  RadioGroupOption,
+} from "@headlessui/vue";
 
 const profileStore = useProfileStore();
 const { t } = useI18n();
@@ -196,23 +204,24 @@ const joinedContentLanguages = computed(() =>
       :description="$t('profile.theme-description')"
       @close="showThemeDialog = false"
     >
-      <ul
+      <RadioGroup
+        v-model="colorMode.preference"
         class="bg-background-2 dark:bg-background-dark-2 rounded-2xl mt-4 font-semibold"
       >
-        <li
+        <RadioGroupOption
           v-for="mode in colorModes"
           :key="mode"
-          class="flex justify-between px-4 py-3 cursor-pointer hover:bg-on-color-2 rounded-2xl"
-          @click="colorMode.preference = mode"
+          :value="mode"
+          class="flex justify-between px-4 py-3 cursor-pointer hover:bg-on-color-2 rounded-2xl w-full"
         >
-          <div>{{ getColorModeName(mode) }}</div>
+          <span>{{ getColorModeName(mode) }}</span>
           <NuxtIcon
             v-if="mode == colorMode.preference"
             name="icon.selected"
             class="text-2xl group-hover:text-4xl inline-block"
           />
-        </li>
-      </ul>
+        </RadioGroupOption>
+      </RadioGroup>
     </DialogBase>
 
     <DialogBase

--- a/components/ProfileMenu.vue
+++ b/components/ProfileMenu.vue
@@ -231,12 +231,12 @@ const joinedContentLanguages = computed(() =>
       @close="showInterfaceLanguageDialog = false"
     >
       <div
-        class="flex content-center gap-4 justify-between bg-background-2 dark:bg-background-dark-2 rounded-2xl p-3"
+        class="bg-background-2 dark:bg-background-dark-2 rounded-2xl p-3 pl-5"
       >
-        <div class="inline-block self-center">
-          {{ $t("profile.select-language") }}
-        </div>
-        <ChangeLocale />
+        <label class="self-center flex items-center gap-4 justify-between">
+          <span>{{ $t("profile.select-language") }}</span>
+          <ChangeLocale />
+        </label>
       </div>
     </DialogBase>
 

--- a/components/ProfileMenu.vue
+++ b/components/ProfileMenu.vue
@@ -76,7 +76,7 @@ const joinedContentLanguages = computed(() =>
         leave-to-class="transform scale-95 opacity-0"
       >
         <MenuItems
-          class="absolute right-0 mt-2 w-56 origin-top-right divide-y divide-label-separator rounded-xl bg-white-1 text-sm shadow-lg ring-1 ring-label-separator focus-visible:outline-none -separator"
+          class="absolute right-0 mt-2 w-56 origin-top-right divide-y divide-label-separator rounded-xl bg-background-3 text-sm shadow-lg ring-1 ring-label-separator focus-visible:outline-none -separator"
         >
           <div class="p-1">
             <MenuItem v-slot="{ active }">
@@ -212,7 +212,7 @@ const joinedContentLanguages = computed(() =>
           v-for="mode in colorModes"
           :key="mode"
           :value="mode"
-          class="flex justify-between px-4 py-3 cursor-pointer hover:bg-on-color-2 rounded-2xl w-full"
+          class="flex justify-between px-4 py-3 cursor-pointer hover:bg-on-color-2 focus-visible:bg-on-color-2 w-full first:rounded-t-2xl last:rounded-b-2xl"
         >
           <span>{{ getColorModeName(mode) }}</span>
           <NuxtIcon

--- a/components/ProfileMenu.vue
+++ b/components/ProfileMenu.vue
@@ -193,10 +193,9 @@ const joinedContentLanguages = computed(() =>
     <DialogBase
       :show="showThemeDialog"
       title="Theme"
+      :description="$t('profile.theme-description')"
       @close="showThemeDialog = false"
     >
-      <div>{{ $t("profile.theme-description") }}</div>
-
       <ul
         class="bg-background-2 dark:bg-background-dark-2 rounded-2xl mt-4 font-semibold"
       >
@@ -219,11 +218,9 @@ const joinedContentLanguages = computed(() =>
     <DialogBase
       :show="showInterfaceLanguageDialog"
       :title="$t('profile.interface-language')"
+      :description="$t('profile.interface-language-description')"
       @close="showInterfaceLanguageDialog = false"
     >
-      {{ $t("profile.interface-language-description") }}
-      <br /><br />
-
       <div
         class="flex content-center bg-background-2 dark:bg-background-dark-2 rounded-2xl p-3"
       >
@@ -237,10 +234,9 @@ const joinedContentLanguages = computed(() =>
     <DialogBase
       :show="showContentLanguageDialog"
       :title="$t('profile.content-language')"
+      :description="$t('profile.content-language-description')"
       @close="showContentLanguageDialog = false"
     >
-      {{ $t("profile.content-language-description") }}
-      <br /><br />
       <p style="background-color: rgba(255, 0, 0, 0.4)">Not implemented yet.</p>
     </DialogBase>
   </div>

--- a/components/dialog/DialogBase.vue
+++ b/components/dialog/DialogBase.vue
@@ -4,11 +4,15 @@ import {
   DialogBackdrop,
   DialogPanel,
   DialogTitle,
+  DialogDescription,
+  TransitionRoot,
+  TransitionChild,
 } from "@headlessui/vue";
 
 defineProps<{
   show: boolean;
   title: string;
+  description?: string;
 }>();
 
 const emit = defineEmits<{
@@ -17,32 +21,59 @@ const emit = defineEmits<{
 </script>
 
 <template>
-  <Dialog :open="show" class="relative z-30" @close="emit('close')">
-    <DialogBackdrop class="fixed inset-0 bg-background-4 opacity-40" />
-
-    <div
-      class="fixed inset-0 flex items-center justify-center content-center"
-      @click="emit('close')"
-    >
-      <DialogPanel
-        class="bg-background-1 text-black-1 dark:text-white-1 rounded-2xl md:w-[500px] lg:w-[600px]"
-        @click.stop
+  <TransitionRoot :show="show" as="template">
+    <Dialog :open="show" class="relative z-30" @close="emit('close')">
+      <TransitionChild
+        as="template"
+        enter="duration-300 ease-out"
+        enter-from="opacity-0"
+        enter-to="opacity-100"
+        leave="duration-200 ease-in"
+        leave-from="opacity-100"
+        leave-to="opacity-0"
       >
-        <div class="flex justify-between items-center mx-5">
-          <DialogTitle class="py-4 font-semibold">{{ title }}</DialogTitle>
-          <ButtonStyled
-            intent="primary"
-            size="small"
-            @click.stop="emit('close')"
+        <DialogBackdrop class="fixed inset-0 bg-background-4 opacity-40" />
+      </TransitionChild>
+
+      <div
+        class="fixed inset-0 flex items-center justify-center content-center"
+        @click="emit('close')"
+      >
+        <TransitionChild
+          as="template"
+          enter="duration-200 ease-out"
+          enter-from="opacity-0 scale-95"
+          enter-to="opacity-100 scale-100"
+          leave="duration-200 ease-in"
+          leave-from="opacity-100 scale-100"
+          leave-to="opacity-0 scale-95"
+        >
+          <DialogPanel
+            class="bg-background-1 text-black-1 dark:text-white-1 rounded-2xl md:w-[500px] lg:w-[600px]"
+            @click.stop
           >
-            {{ $t("profile.done") }}
-          </ButtonStyled>
-        </div>
-        <div class="bg-label-1 dark:bg-label-dark-1 h-[1px] opacity-10"></div>
-        <div class="p-4">
-          <slot />
-        </div>
-      </DialogPanel>
-    </div>
-  </Dialog>
+            <div class="flex justify-between items-center mx-5">
+              <DialogTitle class="py-4 font-semibold">{{ title }}</DialogTitle>
+              <ButtonStyled
+                intent="primary"
+                size="small"
+                @click.stop="emit('close')"
+              >
+                {{ $t("profile.done") }}
+              </ButtonStyled>
+            </div>
+            <div
+              class="bg-label-1 dark:bg-label-dark-1 h-[1px] opacity-10"
+            ></div>
+            <div class="p-4">
+              <DialogDescription v-if="description" class="mb-4">
+                {{ description }}
+              </DialogDescription>
+              <slot />
+            </div>
+          </DialogPanel>
+        </TransitionChild>
+      </div>
+    </Dialog>
+  </TransitionRoot>
 </template>

--- a/components/dialog/DialogBase.vue
+++ b/components/dialog/DialogBase.vue
@@ -12,7 +12,7 @@ const emit = defineEmits<{
 <template>
   <Teleport to="body">
     <div v-if="show" class="relative z-30">
-      <div class="fixed inset-0 bg-background-dark-1 opacity-40"></div>
+      <div class="fixed inset-0 bg-background-4 opacity-40"></div>
 
       <div
         class="fixed inset-0 flex items-center justify-center content-center"

--- a/components/dialog/DialogBase.vue
+++ b/components/dialog/DialogBase.vue
@@ -22,20 +22,19 @@ const emit = defineEmits<{
           class="bg-background-1 text-black-1 dark:text-white-1 rounded-2xl md:w-[500px] lg:w-[600px]"
           @click.stop
         >
-          <div class="flex justify-between mx-5">
+          <div class="flex justify-between items-center mx-5">
             <div class="py-4 font-semibold">{{ title }}</div>
-            <div class="align-middle self-center">
-              <ButtonStyled
-                intent="primary"
-                size="small"
-                @click.stop="emit('close')"
-                >Done</ButtonStyled
-              >
-            </div>
+            <ButtonStyled
+              intent="primary"
+              size="small"
+              @click.stop="emit('close')"
+            >
+              {{ $t("profile.done") }}
+            </ButtonStyled>
           </div>
           <div class="bg-label-1 dark:bg-label-dark-1 h-[1px] opacity-10"></div>
           <div class="p-4">
-            <slot></slot>
+            <slot />
           </div>
         </div>
       </div>

--- a/components/dialog/DialogBase.vue
+++ b/components/dialog/DialogBase.vue
@@ -1,4 +1,11 @@
 <script setup lang="ts">
+import {
+  Dialog,
+  DialogBackdrop,
+  DialogPanel,
+  DialogTitle,
+} from "@headlessui/vue";
+
 defineProps<{
   show: boolean;
   title: string;
@@ -10,34 +17,32 @@ const emit = defineEmits<{
 </script>
 
 <template>
-  <Teleport to="body">
-    <div v-if="show" class="relative z-30">
-      <div class="fixed inset-0 bg-background-4 opacity-40"></div>
+  <Dialog :open="show" class="relative z-30" @close="emit('close')">
+    <DialogBackdrop class="fixed inset-0 bg-background-4 opacity-40" />
 
-      <div
-        class="fixed inset-0 flex items-center justify-center content-center"
-        @click="emit('close')"
+    <div
+      class="fixed inset-0 flex items-center justify-center content-center"
+      @click="emit('close')"
+    >
+      <DialogPanel
+        class="bg-background-1 text-black-1 dark:text-white-1 rounded-2xl md:w-[500px] lg:w-[600px]"
+        @click.stop
       >
-        <div
-          class="bg-background-1 text-black-1 dark:text-white-1 rounded-2xl md:w-[500px] lg:w-[600px]"
-          @click.stop
-        >
-          <div class="flex justify-between items-center mx-5">
-            <div class="py-4 font-semibold">{{ title }}</div>
-            <ButtonStyled
-              intent="primary"
-              size="small"
-              @click.stop="emit('close')"
-            >
-              {{ $t("profile.done") }}
-            </ButtonStyled>
-          </div>
-          <div class="bg-label-1 dark:bg-label-dark-1 h-[1px] opacity-10"></div>
-          <div class="p-4">
-            <slot />
-          </div>
+        <div class="flex justify-between items-center mx-5">
+          <DialogTitle class="py-4 font-semibold">{{ title }}</DialogTitle>
+          <ButtonStyled
+            intent="primary"
+            size="small"
+            @click.stop="emit('close')"
+          >
+            {{ $t("profile.done") }}
+          </ButtonStyled>
         </div>
-      </div>
+        <div class="bg-label-1 dark:bg-label-dark-1 h-[1px] opacity-10"></div>
+        <div class="p-4">
+          <slot />
+        </div>
+      </DialogPanel>
     </div>
-  </Teleport>
+  </Dialog>
 </template>

--- a/locales/en.json
+++ b/locales/en.json
@@ -30,7 +30,8 @@
     "logout": "Sign out",
     "theme-dark": "Dark",
     "theme-light": "Light",
-    "theme-system": "Same as system"
+    "theme-system": "Same as system",
+    "done": "Done"
   },
   "error": {
     "page-not-found": {

--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
     "class-variance-authority": "^0.7.0",
     "cross-env": "^7.0.3",
     "electron-updater": "^6.1.4",
-    "pinia": "^2.1.7"
+    "pinia": "^2.1.7",
+    "vue-draggable-plus": "^0.2.7"
   },
   "devDependencies": {
     "@intlify/eslint-plugin-vue-i18n": "^2.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,6 +35,9 @@ dependencies:
   pinia:
     specifier: ^2.1.7
     version: 2.1.7(typescript@5.2.2)(vue@3.3.4)
+  vue-draggable-plus:
+    specifier: ^0.2.7
+    version: 0.2.7(@types/sortablejs@1.15.7)
 
 devDependencies:
   '@intlify/eslint-plugin-vue-i18n':
@@ -2696,6 +2699,10 @@ packages:
   /@types/sizzle@2.3.3:
     resolution: {integrity: sha512-JYM8x9EGF163bEyhdJBpR2QX1R5naCJHC8ucJylJ3w9/CVBaskdQ8WqBf8MmQrd1kRvp/a4TS8HJ+bxzR7ZJYQ==}
     dev: true
+
+  /@types/sortablejs@1.15.7:
+    resolution: {integrity: sha512-PvgWCx1Lbgm88FdQ6S7OGvLIjWS66mudKPlfdrWil0TjsO5zmoZmzoKiiwRShs1dwPgrlkr0N4ewuy0/+QUXYQ==}
+    dev: false
 
   /@types/verror@1.10.6:
     resolution: {integrity: sha512-NNm+gdePAX1VGvPcGZCDKQZKYSiAWigKhKaz5KF94hG6f2s8de9Ow5+7AbXoeKxL8gavZfk4UquSAygOF2duEQ==}
@@ -12725,6 +12732,18 @@ packages:
   /vue-devtools-stub@0.1.0:
     resolution: {integrity: sha512-RutnB7X8c5hjq39NceArgXg28WZtZpGc3+J16ljMiYnFhKvd8hITxSWQSQ5bvldxMDU6gG5mkxl1MTQLXckVSQ==}
     dev: true
+
+  /vue-draggable-plus@0.2.7(@types/sortablejs@1.15.7):
+    resolution: {integrity: sha512-asNQ4OxTQtN91+m45lh8QEwscXhVveaLvPAzaRXHD8JIk1+SOg7NWPQ9EmUTeNhSP3SGkJ2Agvp5WRDt7vXM8w==}
+    peerDependencies:
+      '@types/sortablejs': ^1.15.0
+      '@vue/composition-api': '*'
+    peerDependenciesMeta:
+      '@vue/composition-api':
+        optional: true
+    dependencies:
+      '@types/sortablejs': 1.15.7
+    dev: false
 
   /vue-eslint-parser@9.3.1(eslint@8.52.0):
     resolution: {integrity: sha512-Clr85iD2XFZ3lJ52/ppmUDG/spxQu6+MAeHXjjyI4I1NUYZ9xmenQp4N0oaHJhrA8OOxltCVxMRfANGa70vU0g==}


### PR DESCRIPTION
Using the HeadlessUI Dialog as a base gives us better accessibility out of the box, with keyboard navigation, close on escape, better screen reader support etc.