### PR TITLE
Added typescript "verbatimModuleSyntax" and rule "import/consistent-type-specifier-style"

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -30,6 +30,7 @@
           "warn",
           { "assertionStyle": "never" }
         ],
+        "import/consistent-type-specifier-style": ["error", "prefer-top-level"],
         "promise/always-return": "off"
       }
     },

--- a/components/AlbumDetails.vue
+++ b/components/AlbumDetails.vue
@@ -1,5 +1,5 @@
 <script lang="ts" setup>
-import { AlbumModel, TrackModel } from "@bcc-code/bmm-sdk-fetch";
+import type { AlbumModel, TrackModel } from "@bcc-code/bmm-sdk-fetch";
 
 const { t } = useI18n();
 

--- a/components/ContentSection.vue
+++ b/components/ContentSection.vue
@@ -1,5 +1,5 @@
 <script lang="ts" setup>
-import { RoutesNamedLocations } from "@typed-router";
+import type { RoutesNamedLocations } from "@typed-router";
 
 withDefaults(
   defineProps<{

--- a/components/ItemCard.vue
+++ b/components/ItemCard.vue
@@ -1,5 +1,5 @@
 <script lang="ts" setup>
-import {
+import type {
   AlbumModel,
   PlaylistModel,
   PodcastModel,

--- a/components/ProtectedImage.spec.ts
+++ b/components/ProtectedImage.spec.ts
@@ -2,7 +2,8 @@
 
 import { describe, it, expect } from "vitest";
 import { flushPromises, mount } from "@vue/test-utils";
-import { AUTH0_INJECTION_KEY, Auth0VueClient } from "@auth0/auth0-vue";
+import { AUTH0_INJECTION_KEY } from "@auth0/auth0-vue";
+import type { Auth0VueClient } from "@auth0/auth0-vue";
 import ProtectedImage from "./ProtectedImage.vue";
 
 describe("component ProtectedImage", () => {

--- a/components/album/AlbumItem.vue
+++ b/components/album/AlbumItem.vue
@@ -1,5 +1,5 @@
 <script lang="ts" setup>
-import { AlbumModel } from "@bcc-code/bmm-sdk-fetch";
+import type { AlbumModel } from "@bcc-code/bmm-sdk-fetch";
 
 defineProps<{
   album: AlbumModel;

--- a/components/album/SubAlbum.vue
+++ b/components/album/SubAlbum.vue
@@ -1,5 +1,5 @@
 <script lang="ts" setup>
-import { AlbumModel, TrackModel } from "@bcc-code/bmm-sdk-fetch";
+import type { AlbumModel, TrackModel } from "@bcc-code/bmm-sdk-fetch";
 
 const props = defineProps<{
   id: number;

--- a/components/contributor/ContributorListItem.vue
+++ b/components/contributor/ContributorListItem.vue
@@ -1,5 +1,5 @@
 <script lang="ts" setup>
-import { ContributorModel } from "@bcc-code/bmm-sdk-fetch";
+import type { ContributorModel } from "@bcc-code/bmm-sdk-fetch";
 
 defineProps<{
   contributor: ContributorModel;

--- a/components/playlist/PlaylistItem.vue
+++ b/components/playlist/PlaylistItem.vue
@@ -1,5 +1,5 @@
 <script lang="ts" setup>
-import { PlaylistModel } from "@bcc-code/bmm-sdk-fetch";
+import type { PlaylistModel } from "@bcc-code/bmm-sdk-fetch";
 
 defineProps<{
   playlist: PlaylistModel;

--- a/components/podcast/PodcastItem.vue
+++ b/components/podcast/PodcastItem.vue
@@ -1,5 +1,5 @@
 <script lang="ts" setup>
-import { PodcastModel } from "@bcc-code/bmm-sdk-fetch";
+import type { PodcastModel } from "@bcc-code/bmm-sdk-fetch";
 
 defineProps<{
   podcast: PodcastModel;

--- a/components/sidebar/SidebarItem.vue
+++ b/components/sidebar/SidebarItem.vue
@@ -1,6 +1,6 @@
 <script lang="ts" setup>
-import { NuxtIconName } from "#build/nuxt-icons";
-import { RoutesNamedLocations } from "@typed-router";
+import type { NuxtIconName } from "#build/nuxt-icons";
+import type { RoutesNamedLocations } from "@typed-router";
 
 withDefaults(
   defineProps<{

--- a/components/track/TrackDetails.vue
+++ b/components/track/TrackDetails.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { TrackModel } from "@bcc-code/bmm-sdk-fetch";
+import type { TrackModel } from "@bcc-code/bmm-sdk-fetch";
 
 const { t } = useI18n();
 

--- a/components/track/TrackItem.vue
+++ b/components/track/TrackItem.vue
@@ -1,7 +1,7 @@
 <script lang="ts" setup>
-import { NuxtIconName } from ".nuxt/nuxt-icons";
-import { RoutesNamedLocations } from ".nuxt/typed-router";
-import { TrackModel } from "@bcc-code/bmm-sdk-fetch";
+import type { NuxtIconName } from ".nuxt/nuxt-icons";
+import type { RoutesNamedLocations } from ".nuxt/typed-router";
+import type { TrackModel } from "@bcc-code/bmm-sdk-fetch";
 import { Menu, MenuButton, MenuItem, MenuItems } from "@headlessui/vue";
 
 const { t } = useI18n();

--- a/components/track/TrackList.vue
+++ b/components/track/TrackList.vue
@@ -1,5 +1,5 @@
 <script lang="ts" setup>
-import { TrackModel } from "@bcc-code/bmm-sdk-fetch";
+import type { TrackModel } from "@bcc-code/bmm-sdk-fetch";
 
 const props = withDefaults(
   defineProps<{

--- a/composables/discover.ts
+++ b/composables/discover.ts
@@ -1,5 +1,5 @@
-import {
-  DiscoverApi,
+import { DiscoverApi } from "@bcc-code/bmm-sdk-fetch";
+import type {
   DiscoverGetRequest,
   SectionHeaderModel,
   IAllDocumentModels,

--- a/composables/track.ts
+++ b/composables/track.ts
@@ -1,4 +1,5 @@
-import { TrackApi, TrackGetRequest } from "@bcc-code/bmm-sdk-fetch";
+import { TrackApi } from "@bcc-code/bmm-sdk-fetch";
+import type { TrackGetRequest } from "@bcc-code/bmm-sdk-fetch";
 
 export function useTracks(options: TrackGetRequest = {}) {
   return reactiveApi(

--- a/i18n.config.ts
+++ b/i18n.config.ts
@@ -1,5 +1,5 @@
 // eslint-disable-next-line import/no-extraneous-dependencies
-import { NuxtI18nOptions } from "@nuxtjs/i18n";
+import type { NuxtI18nOptions } from "@nuxtjs/i18n";
 import { LanguageEnum } from "@bcc-code/bmm-sdk-fetch";
 
 import af from "./locales/af.json";

--- a/modules/icons/generator/index.ts
+++ b/modules/icons/generator/index.ts
@@ -1,7 +1,6 @@
 /* eslint-disable import/prefer-default-export */
 /* eslint import/no-extraneous-dependencies: ["error", {"devDependencies": true}] */
-// eslint-disable-next-line import/no-extraneous-dependencies
-import { Nuxt } from "@nuxt/schema";
+import type { Nuxt } from "@nuxt/schema";
 import chalk from "chalk";
 import { saveGeneratedFile } from "./output";
 import { constructIconNames } from "./parser";

--- a/modules/icons/generator/output.ts
+++ b/modules/icons/generator/output.ts
@@ -1,7 +1,6 @@
 /* eslint-disable import/prefer-default-export */
 /* eslint import/no-extraneous-dependencies: ["error", {"devDependencies": true}] */
-// eslint-disable-next-line import/no-extraneous-dependencies
-import { Nuxt } from "@nuxt/schema";
+import type { Nuxt } from "@nuxt/schema";
 import { addTemplate } from "@nuxt/kit";
 
 export const saveGeneratedFile = (_: Nuxt, iconNames: string[] | null) => {

--- a/modules/icons/runtime/components/nuxt-icon.vue
+++ b/modules/icons/runtime/components/nuxt-icon.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { NuxtIconName } from "#build/nuxt-icons";
+import type { NuxtIconName } from "#build/nuxt-icons";
 import { ref, watchEffect } from "#imports";
 
 const props = withDefaults(

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -1,6 +1,5 @@
 // https://nuxt.com/docs/api/configuration/nuxt-config
-// eslint-disable-next-line import/no-extraneous-dependencies
-import { NuxtConfig } from "nuxt/config";
+import type { NuxtConfig } from "nuxt/config";
 import vueI18n from "./i18n.config";
 
 const modules: NuxtConfig["modules"] = [

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -1,11 +1,8 @@
 <script lang="ts" setup>
-import {
-  DiscoverGetRequest,
-  LanguageEnum,
-  TrackModel,
-} from "@bcc-code/bmm-sdk-fetch";
+import { LanguageEnum } from "@bcc-code/bmm-sdk-fetch";
+import type { DiscoverGetRequest, TrackModel } from "@bcc-code/bmm-sdk-fetch";
 import { breakpointsTailwind, useBreakpoints } from "@vueuse/core";
-import { IDiscoverableGroup } from "~/composables/discover";
+import type { IDiscoverableGroup } from "~/composables/discover";
 
 const { setQueue } = useNuxtApp().$mediaPlayer;
 const userData = useNuxtApp().$userData;

--- a/plugins/3.applicationInsights.ts
+++ b/plugins/3.applicationInsights.ts
@@ -4,7 +4,7 @@
 
 /* eslint-disable no-nested-ternary */
 import { ApplicationInsights } from "@microsoft/applicationinsights-web";
-import { IUserData } from "./2.userData";
+import type { IUserData } from "./2.userData";
 
 export interface AppInsights {
   event: (event: any, customProperties: any) => void;

--- a/plugins/4.mediaPlayer.ts
+++ b/plugins/4.mediaPlayer.ts
@@ -1,6 +1,6 @@
 import { authToken, initMediaPlayer } from "./mediaPlayer/mediaPlayer";
-import { AppInsights } from "./3.applicationInsights";
-import { IUserData } from "./2.userData";
+import type { AppInsights } from "./3.applicationInsights";
+import type { IUserData } from "./2.userData";
 
 export default defineNuxtPlugin((nuxtApp) => {
   const { getAccessTokenSilently, isAuthenticated } =

--- a/plugins/mediaPlayer/Queue.spec.ts
+++ b/plugins/mediaPlayer/Queue.spec.ts
@@ -2,7 +2,7 @@
 
 import { describe, it, expect } from "vitest";
 import { flushPromises } from "@vue/test-utils";
-import { TrackModel } from "@bcc-code/bmm-sdk-fetch";
+import type { TrackModel } from "@bcc-code/bmm-sdk-fetch";
 import Queue from "./Queue";
 
 describe("plugin mediaPlayer Queue", () => {

--- a/plugins/mediaPlayer/Queue.ts
+++ b/plugins/mediaPlayer/Queue.ts
@@ -1,4 +1,4 @@
-import { TrackModel } from "@bcc-code/bmm-sdk-fetch";
+import type { TrackModel } from "@bcc-code/bmm-sdk-fetch";
 
 export default class Queue extends Array<TrackModel> {
   public isShuffled = false;

--- a/plugins/mediaPlayer/mediaPlayer.spec.ts
+++ b/plugins/mediaPlayer/mediaPlayer.spec.ts
@@ -1,11 +1,12 @@
 // @vitest-environment happy-dom
 
-import { describe, it, expect, vi, afterEach, Mock } from "vitest";
-import { TrackModel } from "@bcc-code/bmm-sdk-fetch";
+import { describe, it, expect, vi, afterEach } from "vitest";
+import type { Mock } from "vitest";
+import type { TrackModel } from "@bcc-code/bmm-sdk-fetch";
 import { flushPromises } from "@vue/test-utils";
 import type { UnwrapRef } from "vue";
-import { IUserData } from "plugins/2.userData";
-import { AppInsights } from "../3.applicationInsights";
+import type { IUserData } from "plugins/2.userData";
+import type { AppInsights } from "../3.applicationInsights";
 import Queue from "./Queue";
 import MediaTrack from "./MediaTrack";
 import { initMediaPlayer, MediaPlayerStatus } from "./mediaPlayer";

--- a/plugins/mediaPlayer/mediaPlayer.ts
+++ b/plugins/mediaPlayer/mediaPlayer.ts
@@ -1,7 +1,8 @@
-import { TrackModel, StatisticsApi } from "@bcc-code/bmm-sdk-fetch";
+import { StatisticsApi } from "@bcc-code/bmm-sdk-fetch";
+import type { TrackModel } from "@bcc-code/bmm-sdk-fetch";
 import type { UnwrapRef } from "vue";
-import { IUserData } from "plugins/2.userData";
-import { AppInsights } from "plugins/3.applicationInsights";
+import type { IUserData } from "plugins/2.userData";
+import type { AppInsights } from "plugins/3.applicationInsights";
 import MediaTrack from "./MediaTrack";
 import Queue from "./Queue";
 

--- a/plugins/piniaPersistedState.ts
+++ b/plugins/piniaPersistedState.ts
@@ -1,5 +1,5 @@
 import piniaPluginPersistedstate from "pinia-plugin-persistedstate";
-import { Pinia } from "pinia";
+import type { Pinia } from "pinia";
 
 export default defineNuxtPlugin((nuxtApp) => {
   const piniaApp = nuxtApp.$pinia as Pinia;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,6 +6,7 @@
     "esModuleInterop": true,
     "lib": ["ESNext", "DOM"],
     "noUncheckedIndexedAccess": true,
+    "verbatimModuleSyntax": true, // Can be removed after updating nuxt to v3.8
     "exactOptionalPropertyTypes": true
   }
 }

--- a/utils/reactiveApi.ts
+++ b/utils/reactiveApi.ts
@@ -1,4 +1,4 @@
-import { AsyncData } from "#app";
+import type { AsyncData } from "#app";
 
 export default function reactiveApi<Data, Error>(data: AsyncData<Data, Error>) {
   const stopHandler = watch(


### PR DESCRIPTION
More info: https://typescript-eslint.io/blog/consistent-type-imports-and-exports-why-and-how/

Best to implement it in a separate PR. Will anyways be advisable to do when updating to nuxt v3.8 - so why not already now?