### PR TITLE
Better marquee

### DIFF
--- a/components/MediaPlayer.vue
+++ b/components/MediaPlayer.vue
@@ -70,14 +70,14 @@ const onPointerDownProgressBar = () => {
           <div
             class="flex gap-1 w-full flex-col overflow-hidden whitespace-nowrap"
           >
-            <TextMarquee>
+            <div class="w-full truncate">
               <h3
                 class="truncate text-lg font-semibold leading-tight"
                 :title="currentTrack?.title || ''"
               >
                 {{ currentTrack?.title }}
               </h3>
-            </TextMarquee>
+            </div>
             <div class="w-full truncate text-base leading-snug text-label-2">
               <span
                 v-if="currentTrack?.meta?.artist"

--- a/components/MediaPlayer.vue
+++ b/components/MediaPlayer.vue
@@ -2,9 +2,6 @@
 import { MediaPlayerStatus } from "~/plugins/mediaPlayer/mediaPlayer";
 
 const open = ref(false);
-const titleRef = ref<HTMLElement | null>(null);
-const subTitleRef = ref<HTMLElement | null>(null);
-const titleRefSmallPlayer = ref<HTMLElement | null>(null);
 
 const {
   status,
@@ -32,22 +29,6 @@ const onPointerDownProgressBar = () => {
   // TODO: let user drag the progress-bar on mouse-down,
   // update the time while keeping the song playing,
   // and update the players position only on mouse-up.
-};
-
-const getMarqueeClass = (value: HTMLElement, center: Boolean) => {
-  const centerClasses = center ? { "ml-auto": true, "mr-auto": true } : {};
-  if (value === null) return centerClasses;
-  if (!value || !value.parentElement) return centerClasses;
-  const offset = -(value.scrollWidth - value.parentElement.clientWidth) || 0;
-  value.style.setProperty("--animate-marquee-offset", `${offset}px`);
-  const isWiderThanParent =
-    value &&
-    value.parentElement &&
-    value.scrollWidth > value.parentElement.getBoundingClientRect().width;
-  return {
-    "animate-marquee": isWiderThanParent,
-    ...(isWiderThanParent ? {} : centerClasses),
-  };
 };
 </script>
 
@@ -89,22 +70,14 @@ const getMarqueeClass = (value: HTMLElement, center: Boolean) => {
           <div
             class="flex gap-1 w-full flex-col overflow-hidden whitespace-nowrap"
           >
-            <div
-              ref="titleRefSmallPlayer"
-              class="w-fit"
-              :class="
-                titleRefSmallPlayer
-                  ? getMarqueeClass(titleRefSmallPlayer, false)
-                  : null
-              "
-            >
+            <TextMarquee>
               <h3
                 class="truncate text-lg font-semibold leading-tight"
                 :title="currentTrack?.title || ''"
               >
                 {{ currentTrack?.title }}
               </h3>
-            </div>
+            </TextMarquee>
             <div class="w-full truncate text-base leading-snug text-label-2">
               <span
                 v-if="currentTrack?.meta?.artist"
@@ -197,26 +170,18 @@ const getMarqueeClass = (value: HTMLElement, center: Boolean) => {
         <div
           class="flex flex-col py-3 gap-1 overflow-x-hidden whitespace-nowrap"
         >
-          <div
-            ref="titleRef"
-            class="w-fit"
-            :class="titleRef ? getMarqueeClass(titleRef, true) : null"
-          >
+          <TextMarquee class="m-auto">
             <h3
-              class="text-center text-lg font-semibold leading-tight"
+              class="text-lg font-semibold leading-tight"
               :title="currentTrack?.title || ''"
             >
               {{ currentTrack?.title }}
             </h3>
-          </div>
+          </TextMarquee>
           <div
-            class="overflow-x-hidden whitespace-nowrap text-center text-base leading-snug text-label-2"
+            class="overflow-x-hidden whitespace-nowrap text-base leading-snug text-label-2"
           >
-            <div
-              ref="subTitleRef"
-              class="w-fit"
-              :class="subTitleRef ? getMarqueeClass(subTitleRef, true) : null"
-            >
+            <TextMarquee class="m-auto">
               <span
                 v-if="currentTrack?.meta?.artist"
                 :title="currentTrack?.meta?.artist"
@@ -234,7 +199,7 @@ const getMarqueeClass = (value: HTMLElement, center: Boolean) => {
               >
                 {{ currentTrack.meta?.album }}
               </span>
-            </div>
+            </TextMarquee>
           </div>
         </div>
         <div class="px-4 py-2">

--- a/components/TextMarquee.vue
+++ b/components/TextMarquee.vue
@@ -1,0 +1,64 @@
+<script setup lang="ts">
+defineSlots<{
+  default: (props: {}) => any;
+}>();
+
+const elRef = ref<HTMLElement | null>(null);
+const container = ref<HTMLElement | null>(null);
+const contentIsTooLarge = ref<boolean>(false);
+const mutationObserver = ref<MutationObserver | null>(null);
+const speed = 50; // in pixel per second
+const delay = 2000; // in millisecons
+const bufferSpace = 5; // Only start marquee if content exceepds parent by this amount of pixels
+
+const onSlotContentChange = () => {
+  if (!elRef.value?.parentElement || !container.value) return;
+
+  const { scrollWidth } = container.value;
+  const { clientWidth } = elRef.value.parentElement;
+
+  elRef.value.style.animation = "";
+
+  if (scrollWidth > clientWidth + bufferSpace) {
+    contentIsTooLarge.value = true;
+    setTimeout(() => {
+      elRef.value!.style.animation = `vue-component-text-marquee ${scrollWidth * (1 / speed)}s linear infinite`;
+    }, delay);
+  } else {
+    contentIsTooLarge.value = false;
+  }
+};
+
+onMounted(() => {
+  mutationObserver.value = new MutationObserver(onSlotContentChange);
+
+  mutationObserver.value.observe(container.value!, {
+    childList: true,
+    characterData: true,
+    subtree: true,
+  });
+
+  onSlotContentChange();
+});
+
+onUnmounted(() => {
+  mutationObserver.value?.disconnect();
+});
+</script>
+<template>
+  <div ref="elRef" class="w-fit flex relative">
+    <div ref="container" class="inline-block pr-14"><slot /></div>
+    <div v-if="contentIsTooLarge" class="inline-block pr-14"><slot /></div>
+  </div>
+</template>
+<style>
+@keyframes vue-component-text-marquee {
+  0% {
+    transform: translate(0);
+  }
+
+  100% {
+    transform: translate(-50%);
+  }
+}
+</style>

--- a/components/TextMarquee.vue
+++ b/components/TextMarquee.vue
@@ -47,7 +47,13 @@ onUnmounted(() => {
 </script>
 <template>
   <div ref="elRef" class="w-fit flex relative">
-    <div ref="container" class="inline-block pr-14"><slot /></div>
+    <div
+      ref="container"
+      class="inline-block"
+      :class="{ 'pr-14': contentIsTooLarge }"
+    >
+      <slot />
+    </div>
     <div v-if="contentIsTooLarge" class="inline-block pr-14"><slot /></div>
   </div>
 </template>

--- a/components/TextMarquee.vue
+++ b/components/TextMarquee.vue
@@ -7,7 +7,7 @@ const elRef = ref<HTMLElement | null>(null);
 const container = ref<HTMLElement | null>(null);
 const contentIsTooLarge = ref<boolean>(false);
 const mutationObserver = ref<MutationObserver | null>(null);
-const speed = 50; // in pixel per second
+const speed = 30; // in pixel per second
 const delay = 2000; // in millisecons
 const bufferSpace = 5; // Only start marquee if content exceepds parent by this amount of pixels
 

--- a/modules/figma2tailwind/convertToTailwind.ts
+++ b/modules/figma2tailwind/convertToTailwind.ts
@@ -24,16 +24,6 @@ const config: Partial<Config> = {
     extend: {  
       gridTemplateColumns: {
         tracklist: "3rem auto auto auto auto" 
-      },
-      animation: {
-        marquee: 'marquee 15s ease-in-out infinite',
-      },
-      keyframes: {
-        marquee: {
-          '0%': { transform: 'translateX(0%)' },
-          '85%': { transform: 'translateX(var(--animate-marquee-offset))' },
-          '100%': { transform: 'translateX(0%)' },
-        },
       }
     }
   },


### PR DESCRIPTION
Added a component for content in marquee, but also changed the marquee-effect to be linear, but first start after 2 seconds. Furthermore, the effect will start over again if a new text appears, which also is too long.

The space between the repeated text is `pr-14`, which is added in the `marquee` component if the variable `contentIsTooLarge` is true.

The mini-player does not have the text as marquee (as discussed @kkuepper), but the full-size player has it both for the title and the second line.

The speed is not a fixed amount of seconds, but the `marquee` component has a speed defined in pixel per second.

I also found it quite annoying if a text, which just didn't quite wrap by very few pixel (not noticeable) also was rotating, which is why I added `bufferSpace`. I just have an example for when the title in the mini-player still rotated - could be removed if requested.

This component also readjusts if the effect is not needed anymore due to resizing (fixing https://github.com/bcc-code/bmm-web/pull/296#issuecomment-1937003918).