### PR TITLE
fix: media player auth token was not being refreshed

### DIFF
--- a/plugins/4.mediaPlayer.ts
+++ b/plugins/4.mediaPlayer.ts
@@ -1,20 +1,10 @@
-import { authToken, initMediaPlayer } from "./mediaPlayer/mediaPlayer";
+import { useAuth0 } from "@auth0/auth0-vue";
+import { initMediaPlayer } from "./mediaPlayer/mediaPlayer";
 import type { AppInsights } from "./3.applicationInsights";
 import type { IUserData } from "./2.userData";
 
-export default defineNuxtPlugin((nuxtApp) => {
-  const { getAccessTokenSilently, isAuthenticated } =
-    nuxtApp.vueApp.config.globalProperties.$auth0;
-
-  watch(
-    isAuthenticated,
-    async (authenticated) => {
-      authToken.value = authenticated
-        ? await getAccessTokenSilently()
-        : undefined;
-    },
-    { immediate: true },
-  );
+export default defineNuxtPlugin((_) => {
+  const { getAccessTokenSilently } = useAuth0();
 
   const appInsights: AppInsights = useNuxtApp().$appInsights;
   const userData: IUserData = useNuxtApp().$userData;
@@ -23,6 +13,7 @@ export default defineNuxtPlugin((nuxtApp) => {
     provide: {
       mediaPlayer: initMediaPlayer(
         (src) => new Audio(src),
+        getAccessTokenSilently,
         appInsights,
         userData,
       ),

--- a/plugins/mediaPlayer/mediaPlayer.spec.ts
+++ b/plugins/mediaPlayer/mediaPlayer.spec.ts
@@ -19,7 +19,7 @@ vi.mock("./Queue", async (importOriginal) => {
 });
 
 const appInsights = {
-  event: (_: string, _2: any) => { },
+  event: (_: string, _2: any) => {},
 } as unknown as AppInsights;
 
 const userData: IUserData = { personId: null, age: null, os: "Test" };

--- a/plugins/mediaPlayer/mediaPlayer.spec.ts
+++ b/plugins/mediaPlayer/mediaPlayer.spec.ts
@@ -19,13 +19,14 @@ vi.mock("./Queue", async (importOriginal) => {
 });
 
 const appInsights = {
-  event: (_: string, _2: any) => {},
+  event: (_: string, _2: any) => { },
 } as unknown as AppInsights;
 
 const userData: IUserData = { personId: null, age: null, os: "Test" };
 const setupPlayer = () =>
   initMediaPlayer(
     () => HTMLAudioElement as unknown as globalThis.HTMLAudioElement,
+    () => Promise.resolve("token"),
     appInsights as unknown as AppInsights,
     userData,
   );

--- a/plugins/mediaPlayer/mediaPlayer.spec.ts
+++ b/plugins/mediaPlayer/mediaPlayer.spec.ts
@@ -26,7 +26,7 @@ const userData: IUserData = { personId: null, age: null, os: "Test" };
 const setupPlayer = () =>
   initMediaPlayer(
     () => HTMLAudioElement as unknown as globalThis.HTMLAudioElement,
-    () => Promise.resolve("token"),
+    () => Promise.resolve(undefined),
     appInsights as unknown as AppInsights,
     userData,
   );

--- a/plugins/mediaPlayer/mediaPlayer.ts
+++ b/plugins/mediaPlayer/mediaPlayer.ts
@@ -35,12 +35,11 @@ export interface MediaPlayer {
   replaceCurrent: (track: TrackModel) => void;
 }
 
-export const authToken = ref<string | undefined>();
-
 export const seekOffset = 15;
 
 export const initMediaPlayer = (
   createMedia: (src: string) => HTMLAudioElement,
+  getAccessToken: () => Promise<string>,
   appInsights: AppInsights,
   user: IUserData,
 ): MediaPlayer => {
@@ -70,7 +69,7 @@ export const initMediaPlayer = (
     }
   }
 
-  function initCurrentTrack() {
+  async function initCurrentTrack() {
     const track = queue.value.currentTrack;
     if (!track) {
       stop();
@@ -84,8 +83,9 @@ export const initMediaPlayer = (
       url = `${url}#t=${new Date(nextStartPosition * 1000).toISOString().slice(11, 19)}`;
       nextStartPosition = 0;
     }
+    const token = await getAccessToken();
     activeMedia.value = new MediaTrack(
-      createMedia(authorizedUrl(url, authToken.value)),
+      createMedia(authorizedUrl(url, token)),
     );
     activeMedia.value.registerEvents();
   }

--- a/plugins/mediaPlayer/mediaPlayer.ts
+++ b/plugins/mediaPlayer/mediaPlayer.ts
@@ -39,7 +39,7 @@ export const seekOffset = 15;
 
 export const initMediaPlayer = (
   createMedia: (src: string) => HTMLAudioElement,
-  getAccessToken: () => Promise<string>,
+  getAccessToken: () => Promise<string | undefined>,
   appInsights: AppInsights,
   user: IUserData,
 ): MediaPlayer => {

--- a/plugins/mediaPlayer/mediaPlayer.ts
+++ b/plugins/mediaPlayer/mediaPlayer.ts
@@ -84,9 +84,7 @@ export const initMediaPlayer = (
       nextStartPosition = 0;
     }
     const token = await getAccessToken();
-    activeMedia.value = new MediaTrack(
-      createMedia(authorizedUrl(url, token)),
-    );
+    activeMedia.value = new MediaTrack(createMedia(authorizedUrl(url, token)));
     activeMedia.value.registerEvents();
   }
 


### PR DESCRIPTION
**Problem**
Right now if you leave the tab open until the access token expires, it's not going to refresh the token and playback won't start.
**Cause**
The mediaplayer had an unecessary cache for the token. It's not being refreshed upon expiry because we are watching "isAuthenticated".
**Solution**
The auth0 sdk has an internal cache, so we can use getAccessTokenSilently() directly.
This also mirrors how it's done everywhere else, e.g. https://github.com/bcc-code/bmm-web/blob/0cb1e1d9915236d1e0d66c943015abc253aa2081/components/ProtectedImage.vue#L16