### PR TITLE
Don't pospone track initialization

### DIFF
--- a/plugins/4.mediaPlayer.ts
+++ b/plugins/4.mediaPlayer.ts
@@ -2,6 +2,7 @@ import { useAuth0 } from "@auth0/auth0-vue";
 import { initMediaPlayer } from "./mediaPlayer/mediaPlayer";
 import type { AppInsights } from "./3.applicationInsights";
 import type { IUserData } from "./2.userData";
+import MediaTrack from "./mediaPlayer/MediaTrack";
 
 export default defineNuxtPlugin((_) => {
   const { getAccessTokenSilently } = useAuth0();
@@ -12,7 +13,7 @@ export default defineNuxtPlugin((_) => {
   return {
     provide: {
       mediaPlayer: initMediaPlayer(
-        (src) => new Audio(src),
+        () => new MediaTrack(),
         getAccessTokenSilently,
         appInsights,
         userData,

--- a/plugins/4.mediaPlayer.ts
+++ b/plugins/4.mediaPlayer.ts
@@ -13,8 +13,10 @@ export default defineNuxtPlugin((_) => {
   return {
     provide: {
       mediaPlayer: initMediaPlayer(
-        () => new MediaTrack(),
-        getAccessTokenSilently,
+        (src) =>
+          new MediaTrack(() =>
+            getAccessTokenSilently().then((t) => authorizedUrl(src, t)),
+          ),
         appInsights,
         userData,
       ),

--- a/plugins/mediaPlayer/MediaTrack.spec.ts
+++ b/plugins/mediaPlayer/MediaTrack.spec.ts
@@ -138,6 +138,70 @@ describe("plugin mediaPlayer MediaTrack", () => {
     });
   });
 
+  describe("paused", () => {
+    it("reports the updated paused-state if action is triggered", async () => {
+      // Arrange
+      const audio = new HTMLAudioElement();
+      const mT = ref(new MediaTrackMock());
+      mT.value.audioElementMock =
+        audio as unknown as globalThis.HTMLAudioElement;
+
+      const pauses: boolean[] = [];
+      watch(
+        () => mT.value.paused,
+        (v) => {
+          pauses.push(v);
+        },
+      );
+      mT.value.registerEvents();
+
+      // Act
+      await flushPromises();
+      audio.dispatchEvent(
+        new Event("pause", { bubbles: false, cancelable: false }),
+      );
+      await flushPromises();
+      audio.dispatchEvent(
+        new Event("play", { bubbles: false, cancelable: false }),
+      );
+      await flushPromises();
+
+      // Assert
+      expect(mT.value.paused).equal(false);
+      expect(pauses).eql([true, false]);
+    });
+  });
+
+  describe("ended", () => {
+    it("reports the updated ended-state if action is triggered", async () => {
+      // Arrange
+      const audio = new HTMLAudioElement();
+      const mT = ref(new MediaTrackMock());
+      mT.value.audioElementMock =
+        audio as unknown as globalThis.HTMLAudioElement;
+
+      const ends: boolean[] = [];
+      watch(
+        () => mT.value.ended,
+        (v) => {
+          ends.push(v);
+        },
+      );
+      mT.value.registerEvents();
+
+      // Act
+      await flushPromises();
+      audio.dispatchEvent(
+        new Event("ended", { bubbles: false, cancelable: false }),
+      );
+      await flushPromises();
+
+      // Assert
+      expect(mT.value.ended).equal(true);
+      expect(ends).eql([true]);
+    });
+  });
+
   describe("position", () => {
     it("reports the updated duration after playback has started", async () => {
       // Arrange

--- a/plugins/mediaPlayer/MediaTrack.ts
+++ b/plugins/mediaPlayer/MediaTrack.ts
@@ -5,7 +5,7 @@
  * https://developer.mozilla.org/en-US/docs/Web/API/HTMLAudioElement
  */
 export default class MediaTrack {
-  private audioElement: HTMLAudioElement;
+  protected audioElement: HTMLAudioElement;
 
   public loading = false;
 
@@ -51,8 +51,8 @@ export default class MediaTrack {
    * @param audioElement
    * @param debug Enables logging of all internal changes. Useful when debugging internals of this class.
    */
-  constructor(audioElement: HTMLAudioElement, debug = false) {
-    this.audioElement = audioElement;
+  constructor(debug = false) {
+    this.audioElement = new Audio();
     this.audioElement.autoplay = true;
 
     /* c8 ignore start */
@@ -125,6 +125,26 @@ export default class MediaTrack {
       );
     }
     /* c8 ignore stop */
+  }
+
+  /**
+   * Registering the source in a separate method is needed when
+   * you want to have the element reactive. This method
+   * has to be called after wrapping the object into `ref()`
+   * for `this` to be the proxy created for reactivity.
+   */
+  registerSource(src: Promise<string>) {
+    src
+      .then((_src) => {
+        if (!this.ended) {
+          this.audioElement.src = _src;
+        }
+      })
+      .catch((_) => {
+        // TODO: Define what to do when getting a token fails. For now, we report the track as "played to the end".
+        this.ended = true;
+        this.destroy();
+      });
   }
 
   /**

--- a/plugins/mediaPlayer/mediaPlayer.spec.ts
+++ b/plugins/mediaPlayer/mediaPlayer.spec.ts
@@ -25,7 +25,7 @@ const appInsights = {
 const userData: IUserData = { personId: null, age: null, os: "Test" };
 const setupPlayer = () =>
   initMediaPlayer(
-    () => HTMLAudioElement as unknown as globalThis.HTMLAudioElement,
+    () => new MediaTrack(),
     () => Promise.resolve(undefined),
     appInsights as unknown as AppInsights,
     userData,

--- a/plugins/mediaPlayer/mediaPlayer.spec.ts
+++ b/plugins/mediaPlayer/mediaPlayer.spec.ts
@@ -25,8 +25,7 @@ const appInsights = {
 const userData: IUserData = { personId: null, age: null, os: "Test" };
 const setupPlayer = () =>
   initMediaPlayer(
-    () => new MediaTrack(),
-    () => Promise.resolve(undefined),
+    (src) => new MediaTrack(() => Promise.resolve(src)),
     appInsights as unknown as AppInsights,
     userData,
   );

--- a/plugins/mediaPlayer/mediaPlayer.ts
+++ b/plugins/mediaPlayer/mediaPlayer.ts
@@ -38,8 +38,7 @@ export interface MediaPlayer {
 export const seekOffset = 15;
 
 export const initMediaPlayer = (
-  createMediaTrack: () => MediaTrack,
-  getAccessToken: () => Promise<string | undefined>,
+  createMediaTrack: (src: string) => MediaTrack,
   appInsights: AppInsights,
   user: IUserData,
 ): MediaPlayer => {
@@ -83,10 +82,8 @@ export const initMediaPlayer = (
       url = `${url}#t=${new Date(nextStartPosition * 1000).toISOString().slice(11, 19)}`;
       nextStartPosition = 0;
     }
-    activeMedia.value = createMediaTrack();
-    activeMedia.value.registerSource(
-      getAccessToken().then((t) => authorizedUrl(url, t)),
-    );
+    activeMedia.value = createMediaTrack(url);
+    activeMedia.value.registerSource();
     activeMedia.value.registerEvents();
   }
 

--- a/plugins/mediaPlayer/mediaPlayer.ts
+++ b/plugins/mediaPlayer/mediaPlayer.ts
@@ -38,7 +38,7 @@ export interface MediaPlayer {
 export const seekOffset = 15;
 
 export const initMediaPlayer = (
-  createMedia: (src: string) => HTMLAudioElement,
+  createMediaTrack: () => MediaTrack,
   getAccessToken: () => Promise<string | undefined>,
   appInsights: AppInsights,
   user: IUserData,
@@ -69,7 +69,7 @@ export const initMediaPlayer = (
     }
   }
 
-  async function initCurrentTrack() {
+  function initCurrentTrack() {
     const track = queue.value.currentTrack;
     if (!track) {
       stop();
@@ -83,8 +83,10 @@ export const initMediaPlayer = (
       url = `${url}#t=${new Date(nextStartPosition * 1000).toISOString().slice(11, 19)}`;
       nextStartPosition = 0;
     }
-    const token = await getAccessToken();
-    activeMedia.value = new MediaTrack(createMedia(authorizedUrl(url, token)));
+    activeMedia.value = createMediaTrack();
+    activeMedia.value.registerSource(
+      getAccessToken().then((t) => authorizedUrl(url, t)),
+    );
     activeMedia.value.registerEvents();
   }
 


### PR DESCRIPTION
In PR #341 a mechanism was introduced which refetches the access-token before the start of every track (if not cached - see [`getAccessTokenSilently()`](https://auth0.github.io/auth0-vue/interfaces/GetTokenSilentlyOptions.html)).

Since `getAccessTokenSilently()` returns a promise, this would delay the instantiation of the `MediaTrack` item, means, the media player will show something old, as the new track has not been set yet. Neither are errors handled.

I've refactored the `MediaTrack` class to allow for a delayed setting of the source and some error handling if the token cannot be fetched. ~Currently, we report the song as ended, which would skip the song and continue to the next, which might fail again and thus continue to the end of the list.~ IMO, this is at least better than not handling errors. Now we have the choice to decide what we want to do. We could even refactor the `MediaTrack` to try setting the source again if we decide that that's a better strategy.

**UPDATE:** I've changed the code to pause if `getAccessTokenSilently()` fails to return a string. This way, the user could e.g. check his connection and resume at the song he wanted to listen to. After all, this is most likely not a problem which could be resolved by skipping a song, so this is IMO the better approach.