### PR TITLE
Reporting all error responses

### DIFF
--- a/composables/useShortcuts.ts
+++ b/composables/useShortcuts.ts
@@ -21,7 +21,7 @@ export const privateUseShortcuts = () => {
     );
 
     if (isUsingInput) {
-      return ((activeElement.value as any)?.name as string) || true;
+      return (activeElement.value as any)?.name || true;
     }
 
     return false;

--- a/plugins/2.bmm-api.ts
+++ b/plugins/2.bmm-api.ts
@@ -35,6 +35,21 @@ export default defineNuxtPlugin((nuxtApp) => {
 
           return ctx;
         },
+        post: async (ctx) => {
+          if (
+            !ctx.response ||
+            ctx.response.status < 200 ||
+            ctx.response.status > 300
+          ) {
+            const errorObject = await ctx.response?.json();
+            useNuxtApp().$appInsights.event("request failed", {
+              url: ctx.url,
+              errorCode: errorObject.code,
+              errorMessage: errorObject.message,
+              errorList: errorObject.errors,
+            });
+          }
+        },
         onError: async (ctx) => {
           const errorObject = await ctx.response?.json();
           useNuxtApp().$appInsights.event("request failed", {

--- a/utils/reactiveApi.ts
+++ b/utils/reactiveApi.ts
@@ -8,19 +8,5 @@ export default function reactiveApi<Data, Error>(data: AsyncData<Data, Error>) {
     },
   );
 
-  // Todo: remove once bmm-api correctly calls onError()
-  watch(data.error, async () => {
-    if (data.error.value) {
-      const e = data.error.value as any;
-      const errorObject = await e.response.json();
-      useNuxtApp().$appInsights.event("request failed", {
-        url: e.response.url,
-        errorCode: errorObject.code,
-        errorMessage: errorObject.message,
-        errorList: errorObject.errors,
-      });
-    }
-  });
-
   return { ...data, stopHandler };
 }


### PR DESCRIPTION
but without requiring a change on the API. Furthermore, we can now better distinguish between two types of errors: 1. Errors most likely on the client (no response) and 2. an error response.