### PR TITLE
fix: adopt forward-compatible approach to `builder:watch`

### DIFF
--- a/modules/figma2tailwind/index.ts
+++ b/modules/figma2tailwind/index.ts
@@ -1,3 +1,4 @@
+import { relative, resolve } from 'node:path'
 /* eslint-disable import/no-extraneous-dependencies */
 import { defineNuxtModule } from "@nuxt/kit";
 import logSymbols from "log-symbols";
@@ -24,6 +25,7 @@ export default defineNuxtModule({
     }
 
     nuxt.hook("builder:watch", async (__, watchedPath) => {
+      watchedPath = relative(nuxt.options.srcDir, resolve(nuxt.options.srcDir, watchedPath))
       if (watchedPath === "assets/design-tokens/tokens.json") {
         await runConverter();
       }

--- a/modules/figma2tailwind/index.ts
+++ b/modules/figma2tailwind/index.ts
@@ -1,4 +1,4 @@
-import { relative, resolve } from 'node:path'
+import { relative, resolve } from "node:path";
 /* eslint-disable import/no-extraneous-dependencies */
 import { defineNuxtModule } from "@nuxt/kit";
 import logSymbols from "log-symbols";
@@ -24,9 +24,12 @@ export default defineNuxtModule({
       }
     }
 
-    nuxt.hook("builder:watch", async (__, watchedPath) => {
-      watchedPath = relative(nuxt.options.srcDir, resolve(nuxt.options.srcDir, watchedPath))
-      if (watchedPath === "assets/design-tokens/tokens.json") {
+    nuxt.hook("builder:watch", async (__, path) => {
+      const relativePath = relative(
+        nuxt.options.srcDir,
+        resolve(nuxt.options.srcDir, path),
+      );
+      if (relativePath === "assets/design-tokens/tokens.json") {
         await runConverter();
       }
     });

--- a/modules/icons/generator/index.ts
+++ b/modules/icons/generator/index.ts
@@ -1,4 +1,4 @@
-import { relative, resolve } from 'node:path'
+import { relative, resolve } from "node:path";
 /* eslint-disable import/prefer-default-export */
 /* eslint import/no-extraneous-dependencies: ["error", {"devDependencies": true}] */
 import type { Nuxt } from "@nuxt/schema";
@@ -22,9 +22,12 @@ export async function CreateTypedIcons({
   try {
     if (!isHookCall) {
       if (location) {
-        nuxt.hook("builder:watch", (_, watchedPath) => {
-          watchedPath = relative(nuxt.options.srcDir, resolve(nuxt.options.srcDir, watchedPath))
-          if (watchedPath.startsWith(location)) {
+        nuxt.hook("builder:watch", (_, path) => {
+          const relativePath = relative(
+            nuxt.options.srcDir,
+            resolve(nuxt.options.srcDir, path),
+          );
+          if (relativePath.startsWith(location)) {
             CreateTypedIcons({
               nuxt,
               location,

--- a/modules/icons/generator/index.ts
+++ b/modules/icons/generator/index.ts
@@ -1,3 +1,4 @@
+import { relative, resolve } from 'node:path'
 /* eslint-disable import/prefer-default-export */
 /* eslint import/no-extraneous-dependencies: ["error", {"devDependencies": true}] */
 import type { Nuxt } from "@nuxt/schema";
@@ -22,6 +23,7 @@ export async function CreateTypedIcons({
     if (!isHookCall) {
       if (location) {
         nuxt.hook("builder:watch", (_, watchedPath) => {
+          watchedPath = relative(nuxt.options.srcDir, resolve(nuxt.options.srcDir, watchedPath))
           if (watchedPath.startsWith(location)) {
             CreateTypedIcons({
               nuxt,


### PR DESCRIPTION
We are planning to move to [emitting absolute paths in `builder:watch` in Nuxt v4](https://github.com/nuxt/nuxt/issues/25339). You can see a little more about the history in the PR linked in that issue.

This PR is an attempt to use a forward/backward compatible approach, namely resolving the path to ensure it's absolute, then making it relative so your existing code will continue to work.

This should be safe to merge as is, but do let me know if you have any concerns about this approach.

