### PR TITLE
Pause autoplay on error

### DIFF
--- a/plugins/mediaPlayer/MediaTrack.ts
+++ b/plugins/mediaPlayer/MediaTrack.ts
@@ -149,6 +149,13 @@ export default class MediaTrack {
       .then((_src) => {
         if (!this.ended) {
           this.audioElement.src = _src;
+
+          // This is to check whether a track can actually play after a source has been registered. Was implemented
+          // See: https://www.chromium.org/audio-video/autoplay/ and https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement/play#exceptions
+          // The guide https://developer.mozilla.org/en-US/docs/Web/Media/Autoplay_guide cannot really be used because the there listed function Navigator.getAutoplayPolicy() is only available on Firefox.
+          if (this.audioElement.autoplay) {
+            this.playAudioElement();
+          }
         }
       })
       .catch((_) => {
@@ -214,9 +221,17 @@ export default class MediaTrack {
     });
   }
 
+  playAudioElement() {
+    this.audioElement.play().catch((e: unknown) => {
+      // Set this track to paused on error. This error can occur for multiple reasons.
+      // See https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement/play#exceptions
+      this.paused = true;
+    });
+  }
+
   play() {
     if (this.audioElement.currentSrc) {
-      this.audioElement.play();
+      this.playAudioElement();
     } else {
       this.registerSource();
     }

--- a/plugins/mediaPlayer/MediaTrack.ts
+++ b/plugins/mediaPlayer/MediaTrack.ts
@@ -57,7 +57,7 @@ export default class MediaTrack {
    */
   constructor(
     srcGen: () => Promise<string>,
-    onError: (e: MediaError | null) => void,
+    onError: (e: MediaError | DOMException | unknown | null) => void,
     debug = false,
   ) {
     this.srcGenerator = srcGen;
@@ -226,6 +226,9 @@ export default class MediaTrack {
       // Set this track to paused on error. This error can occur for multiple reasons.
       // See https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement/play#exceptions
       this.paused = true;
+
+      // DOMException (NotAllowedError or NotSupportedError) or any other the browser might choose.
+      this.onError(e);
     });
   }
 


### PR DESCRIPTION
Fixes #328.

I've also added error reporting for thrown elements on `play()`. All of them (excepted for `NotAllowedError`) are reported. @kkuepper please let me know if you want them reported as well. Those are the errors you faced in #328.