### PR TITLE
fix: cache currentuser composable

### DIFF
--- a/components/track/TrackMenu.vue
+++ b/components/track/TrackMenu.vue
@@ -4,6 +4,7 @@ import { Menu, MenuButton, MenuItem, MenuItems } from "@headlessui/vue";
 
 const runtimeConfig = useRuntimeConfig();
 const { t } = useI18n();
+const { $appInsights } = useNuxtApp();
 const { addNext, addToQueue } = useNuxtApp().$mediaPlayer;
 
 const copyToClipboardComponent = ref<null | { copyToClipboard: () => void }>(
@@ -54,7 +55,10 @@ const dropdownMenuItemsForTrack = (track: TrackModel) => {
       clickFunction: async () => {
         const result = await download(track);
         if (result === "no-permission") {
+          $appInsights.event("denied downloading track", { trackId: track.id });
           showDownloadDialog.value = true;
+        } else {
+          $appInsights.event("track downloaded", { trackId: track.id });
         }
       },
     });

--- a/composables/user.ts
+++ b/composables/user.ts
@@ -1,9 +1,11 @@
+import type { AsyncData } from "#app";
 import { CurrentUserApi } from "@bcc-code/bmm-sdk-fetch";
+import type { UserModel } from "@bcc-code/bmm-sdk-fetch";
 
-export function useCurrentUser() {
-  return reactiveApi(
-    useLazyAsyncData(`current-user`, () =>
-      new CurrentUserApi().currentUserGet(),
-    ),
+let cachedComposable: AsyncData<UserModel, Error | null> | null = null;
+export function useCurrentUser(): AsyncData<UserModel, Error | null> {
+  cachedComposable ??= useAsyncData(`current-user-asyncdata`, () =>
+    new CurrentUserApi().currentUserGet(), { dedupe: 'defer', }
   );
+  return cachedComposable!;
 }

--- a/composables/user.ts
+++ b/composables/user.ts
@@ -4,8 +4,10 @@ import type { UserModel } from "@bcc-code/bmm-sdk-fetch";
 
 let cachedComposable: AsyncData<UserModel, Error | null> | null = null;
 export function useCurrentUser(): AsyncData<UserModel, Error | null> {
-  cachedComposable ??= useAsyncData(`current-user-asyncdata`, () =>
-    new CurrentUserApi().currentUserGet(), { dedupe: 'defer', }
+  cachedComposable ??= useAsyncData(
+    `current-user-asyncdata`,
+    () => new CurrentUserApi().currentUserGet(),
+    { dedupe: "defer" },
   );
   return cachedComposable!;
 }


### PR DESCRIPTION
Normally useAsyncData with a key and dedupe is enough, as it's cached, but since this is only used 1 place in the app, the cache clears whenever all "listening" scopes have unmounted. So we need to cache the thing.

Feels like it should be simpler than this but I couldn't think of anything if one wants to use useAsyncData (it's handy as it gives you loading states etc ootb).