### PR TITLE
fix back button not working on 1st load in Electron

### DIFF
--- a/components/AppToolbar.vue
+++ b/components/AppToolbar.vue
@@ -1,6 +1,6 @@
 <script setup type="ts">
 const route = useRoute();
-const hasHistory = () => window.history.length > 1; // using a computed() doesn't work on inital load in the Electron app. No idea why.
+const hasHistory = () => window.history.length > 1; // using a computed() doesn't work on inital load in the Electron app. No idea why. See PR #433
 </script>
 <template>
   <header

--- a/components/AppToolbar.vue
+++ b/components/AppToolbar.vue
@@ -1,6 +1,6 @@
 <script setup type="ts">
 const route = useRoute();
-const showBackButton = computed(() => globalThis.history.length > 1 && route.name !== "index" && route.name !== "search-term" && route.name !== "browse");
+const hasHistory = () => window.history.length > 1; // using a computed() doesn't work on inital load in the Electron app. No idea why.
 </script>
 <template>
   <header
@@ -13,7 +13,12 @@ const showBackButton = computed(() => globalThis.history.length > 1 && route.nam
         style="-webkit-app-region: no-drag"
       ></div>
       <div
-        v-if="showBackButton"
+        v-if="
+          hasHistory &&
+          route.name !== 'index' &&
+          route.name !== 'search-term' &&
+          route.name !== 'browse'
+        "
         class="cursor-pointer p-4"
         style="-webkit-app-region: no-drag"
         @click="$router.back()"


### PR DESCRIPTION
reproduction steps:
- open Electron app (tested on M1 Mac)
- open a playlist
- -> no back button appearing
- hit Cmd + R (which refreshes the website)
- -> back button is now there