### PR TITLE
Queue: Add reorder functionality

### DIFF
--- a/components/media-player/MediaPlayerOpen.vue
+++ b/components/media-player/MediaPlayerOpen.vue
@@ -28,19 +28,19 @@ const {
 } = useNuxtApp().$mediaPlayer;
 
 function isCurrentTrack(index: number) {
-  return queue.value.index === index
+  return queue.value.index === index;
 }
 
-const queueListElement = ref<HTMLUListElement>()
+const queueListElement = ref<HTMLUListElement>();
 
 useDraggable(queueListElement, queue, {
   animation: 200,
   onSort({ oldIndex, newIndex }) {
-    if(oldIndex === undefined || newIndex === undefined) return
+    if (oldIndex === undefined || newIndex === undefined) return;
 
-    queue.value.moveTrack(oldIndex, newIndex)
-  }
-}) 
+    queue.value.moveTrack(oldIndex, newIndex);
+  },
+});
 </script>
 
 <template>

--- a/components/media-player/MediaPlayerOpen.vue
+++ b/components/media-player/MediaPlayerOpen.vue
@@ -1,7 +1,6 @@
 <script setup lang="ts">
 import { MediaPlayerStatus } from "~/plugins/mediaPlayer/mediaPlayer";
 import { useDraggable } from "vue-draggable-plus";
-import type { TrackModel } from "@bcc-code/bmm-sdk-fetch";
 
 const { t } = useI18n();
 
@@ -26,11 +25,10 @@ const {
   rewind,
   fastForward,
   repeatStatus,
-  moveTrack
 } = useNuxtApp().$mediaPlayer;
 
-function isCurrentTrack(track: TrackModel) {
-  return track.id === currentTrack.value?.id;
+function isCurrentTrack(index: number) {
+  return queue.value.index === index
 }
 
 const queueListElement = ref<HTMLUListElement>()
@@ -40,7 +38,7 @@ useDraggable(queueListElement, queue, {
   onSort({ oldIndex, newIndex }) {
     if(oldIndex === undefined || newIndex === undefined) return
 
-    moveTrack(oldIndex, newIndex)
+    queue.value.moveTrack(oldIndex, newIndex)
   }
 }) 
 </script>
@@ -220,7 +218,7 @@ useDraggable(queueListElement, queue, {
         <li v-for="(item, i) in queue" :key="item.id" @click="queue.index = i">
           <div
             :class="
-              isCurrentTrack(item) ? 'bg-tint text-black-1 hover:bg-tint' : ''
+              isCurrentTrack(i) ? 'bg-tint text-black-1 hover:bg-tint' : ''
             "
             class="flex cursor-pointer justify-between gap-2 rounded-xl px-3 py-2 transition-all duration-500 ease-out hover:bg-background-2"
           >
@@ -228,7 +226,7 @@ useDraggable(queueListElement, queue, {
               <div>{{ trackTitleField(item) }}</div>
               <div
                 class="text-sm"
-                :class="isCurrentTrack(item) ? 'text-black-2' : 'text-label-2'"
+                :class="isCurrentTrack(i) ? 'text-black-2' : 'text-label-2'"
               >
                 <span>
                   {{ trackSubtitleField(item) }}
@@ -239,7 +237,7 @@ useDraggable(queueListElement, queue, {
             <div class="flex items-center justify-between gap-2">
               <TrackMenu :track="item" />
               <NuxtIcon
-                v-if="isCurrentTrack(item) && status !== MediaPlayerStatus.Stopped"
+                v-if="isCurrentTrack(i) && status !== MediaPlayerStatus.Stopped"
                 name="icon.playing.animation"
                 filled
                 class="text-2xl"
@@ -251,7 +249,7 @@ useDraggable(queueListElement, queue, {
           </div>
 
           <hr
-            v-if="!(queue.index - 1 === i || isCurrentTrack(item))"
+            v-if="!(queue.index - 1 === i || isCurrentTrack(i))"
             class="border-label-separator"
           />
         </li>

--- a/components/media-player/MediaPlayerOpen.vue
+++ b/components/media-player/MediaPlayerOpen.vue
@@ -220,7 +220,7 @@ useDraggable(queueListElement, queue, {
             :class="
               isCurrentTrack(i) ? 'bg-tint text-black-1 hover:bg-tint' : ''
             "
-            class="flex cursor-pointer justify-between gap-2 rounded-xl px-3 py-2 transition-all duration-500 ease-out hover:bg-background-2"
+            class="flex cursor-row-resize justify-between gap-2 rounded-xl px-3 py-2 transition-all duration-500 ease-out hover:bg-background-2"
           >
             <div class="truncate">
               <div>{{ trackTitleField(item) }}</div>

--- a/plugins/mediaPlayer/Queue.spec.ts
+++ b/plugins/mediaPlayer/Queue.spec.ts
@@ -359,7 +359,7 @@ describe("plugin mediaPlayer Queue", () => {
         () => qObject.value?.index,
         (v) => {
           indexes.push(v);
-        }
+        },
       );
 
       qObject.value = new Queue(
@@ -376,7 +376,7 @@ describe("plugin mediaPlayer Queue", () => {
 
       // Assert
       expect(indexes).eql([0, 3]);
-      expect(qObject.value.at(3)).eql(t)
+      expect(qObject.value.at(3)).eql(t);
     });
-  })
+  });
 });

--- a/plugins/mediaPlayer/Queue.spec.ts
+++ b/plugins/mediaPlayer/Queue.spec.ts
@@ -363,7 +363,7 @@ describe("plugin mediaPlayer Queue", () => {
       );
 
       qObject.value = new Queue(
-        new Array(50).fill(0).map((_, i) => track(i)),
+        new Array(10).fill(0).map((_, i) => track(i)),
         0,
       );
 
@@ -377,6 +377,32 @@ describe("plugin mediaPlayer Queue", () => {
       // Assert
       expect(indexes).eql([0, 3]);
       expect(qObject.value.at(3)).eql(t);
+    });
+
+    it("reordering doesn't change the current track", async () => {
+      // Arrange
+      const qObject = ref<Queue | undefined>();
+      const changes: (TrackModel | undefined)[] = []
+
+      qObject.value = new Queue(
+        new Array(10).fill(0).map((_, i) => track(i)),
+        0,
+      );
+
+      watch(
+        () => qObject.value?.currentTrack,
+        (v) => {
+          changes.push(v);
+        },
+      );
+
+      // Act
+      await flushPromises();
+      qObject.value.moveTrack(0, 3);
+      await flushPromises();
+
+      // Assert
+      expect(changes.length).eql(0);
     });
   });
 });

--- a/plugins/mediaPlayer/Queue.spec.ts
+++ b/plugins/mediaPlayer/Queue.spec.ts
@@ -382,7 +382,7 @@ describe("plugin mediaPlayer Queue", () => {
     it("reordering doesn't change the current track", async () => {
       // Arrange
       const qObject = ref<Queue | undefined>();
-      const changes: (TrackModel | undefined)[] = []
+      const changes: (TrackModel | undefined)[] = [];
 
       qObject.value = new Queue(
         new Array(10).fill(0).map((_, i) => track(i)),

--- a/plugins/mediaPlayer/Queue.spec.ts
+++ b/plugins/mediaPlayer/Queue.spec.ts
@@ -348,4 +348,35 @@ describe("plugin mediaPlayer Queue", () => {
       expect(tracks).eql([track(49)]);
     });
   });
+
+  describe("reordering", () => {
+    it("can reorder the queue", async () => {
+      // Arrange
+      const qObject = ref<Queue | undefined>();
+      const indexes: (number | undefined)[] = [];
+
+      watch(
+        () => qObject.value?.index,
+        (v) => {
+          indexes.push(v);
+        }
+      );
+
+      qObject.value = new Queue(
+        new Array(50).fill(0).map((_, i) => track(i)),
+        0,
+      );
+
+      // Act
+      await flushPromises();
+      const t = qObject.value.at(0);
+      await flushPromises();
+      qObject.value.moveTrack(0, 3);
+      await flushPromises();
+
+      // Assert
+      expect(indexes).eql([0, 3]);
+      expect(qObject.value.at(3)).eql(t)
+    });
+  })
 });

--- a/plugins/mediaPlayer/Queue.ts
+++ b/plugins/mediaPlayer/Queue.ts
@@ -45,12 +45,11 @@ export default class Queue extends Array<TrackModel> {
   }
 
   private reevaluateIndex() {
-    this.i = this.findIndex(v => v === this.currentTrack) || 0;
+    this.i = this.findIndex((v) => v === this.currentTrack) || 0;
   }
 
   public shuffle() {
     if (this.sortedArray) return;
-
 
     this.sortedArray = [...this];
     this.sort((a, b) => {
@@ -59,8 +58,8 @@ export default class Queue extends Array<TrackModel> {
       return Math.random() - 0.5;
     });
     this.isShuffled = true;
-    
-    this.reevaluateIndex()
+
+    this.reevaluateIndex();
   }
 
   public unshuffle() {
@@ -72,7 +71,7 @@ export default class Queue extends Array<TrackModel> {
     this.sortedArray = undefined;
     this.isShuffled = false;
 
-    this.reevaluateIndex()
+    this.reevaluateIndex();
   }
 
   public moveTrack(fromIndex: number, toIndex: number) {
@@ -82,6 +81,6 @@ export default class Queue extends Array<TrackModel> {
     this.splice(fromIndex, 1);
     this.splice(toIndex, 0, fromTrack);
 
-    this.reevaluateIndex()
+    this.reevaluateIndex();
   }
 }

--- a/plugins/mediaPlayer/Queue.ts
+++ b/plugins/mediaPlayer/Queue.ts
@@ -44,10 +44,14 @@ export default class Queue extends Array<TrackModel> {
     this.index = index;
   }
 
+  private reevaluateIndex() {
+    this.i = this.findIndex(v => v === this.currentTrack) || 0;
+  }
+
   public shuffle() {
     if (this.sortedArray) return;
 
-    const playingTrack = this.currentTrack;
+
     this.sortedArray = [...this];
     this.sort((a, b) => {
       if (a === this.currentTrack) return -1;
@@ -55,18 +59,29 @@ export default class Queue extends Array<TrackModel> {
       return Math.random() - 0.5;
     });
     this.isShuffled = true;
-    this.i = this.findIndex((v) => v === playingTrack) || 0;
+    
+    this.reevaluateIndex()
   }
 
   public unshuffle() {
     if (!this.sortedArray) return;
 
-    const playingTrack = this.currentTrack;
     this.sortedArray.forEach((el, i) => {
       this[i] = el;
     });
     this.sortedArray = undefined;
     this.isShuffled = false;
-    this.i = this.findIndex((v) => v === playingTrack) || 0;
+
+    this.reevaluateIndex()
+  }
+
+  public moveTrack(fromIndex: number, toIndex: number) {
+    const fromTrack = this.at(fromIndex);
+    if (!fromTrack) return;
+
+    this.splice(fromIndex, 1);
+    this.splice(toIndex, 0, fromTrack);
+
+    this.reevaluateIndex()
   }
 }

--- a/plugins/mediaPlayer/mediaPlayer.ts
+++ b/plugins/mediaPlayer/mediaPlayer.ts
@@ -45,7 +45,6 @@ export interface MediaPlayer {
   addNext: (track: TrackModel) => void;
   replaceCurrent: (track: TrackModel) => void;
   repeatStatus: Ref<RepeatStatus>;
-  moveTrack(fromIndex: number, toIndex: number): void;
 }
 
 export const seekOffset = 15;
@@ -280,14 +279,6 @@ export const initMediaPlayer = (
     }
   }
 
-  function moveTrack(fromIndex: number, toIndex: number) {
-    const fromTrack = queue.value.at(fromIndex);
-    if (!fromTrack) return;
-
-    queue.value.splice(fromIndex, 1);
-    queue.value.splice(toIndex, 0, fromTrack);
-  }
-
   return {
     status: computed(() => {
       if (!activeMedia.value) return MediaPlayerStatus.Stopped;
@@ -319,6 +310,5 @@ export const initMediaPlayer = (
     addNext,
     replaceCurrent,
     repeatStatus,
-    moveTrack
   };
 };

--- a/plugins/mediaPlayer/mediaPlayer.ts
+++ b/plugins/mediaPlayer/mediaPlayer.ts
@@ -45,6 +45,7 @@ export interface MediaPlayer {
   addNext: (track: TrackModel) => void;
   replaceCurrent: (track: TrackModel) => void;
   repeatStatus: Ref<RepeatStatus>;
+  moveTrack(fromIndex: number, toIndex: number): void;
 }
 
 export const seekOffset = 15;
@@ -279,6 +280,14 @@ export const initMediaPlayer = (
     }
   }
 
+  function moveTrack(fromIndex: number, toIndex: number) {
+    const fromTrack = queue.value.at(fromIndex);
+    if (!fromTrack) return;
+
+    queue.value.splice(fromIndex, 1);
+    queue.value.splice(toIndex, 0, fromTrack);
+  }
+
   return {
     status: computed(() => {
       if (!activeMedia.value) return MediaPlayerStatus.Stopped;
@@ -310,5 +319,6 @@ export const initMediaPlayer = (
     addNext,
     replaceCurrent,
     repeatStatus,
+    moveTrack
   };
 };


### PR DESCRIPTION
Fixes #189 (?)

I used the [vue-draggable-plus](https://github.com/Alfred-Skyblue/vue-draggable-plus), as [vue-draggable-next](https://github.com/SortableJS/vue.draggable.next) doesn't have great TypeScript support, and seems not actively maintained.

https://github.com/bcc-code/bmm-web/assets/18753964/d8e72a9e-fa4d-4734-8a7b-07b907723106