### PR TITLE
provide playbackOrigin for CuratedPlaylist, Contributor and Tile

### DIFF
--- a/components/DocumentList.vue
+++ b/components/DocumentList.vue
@@ -283,6 +283,7 @@ onMounted(() => {
               :is-track-type-known="true"
               :use-daily-podcast-view="useDailyPodcastView"
               show-thumbnail
+              :origin="props.origin"
               @play-track="playItem(item, group)"
             />
             <GenericListItem

--- a/components/DocumentList.vue
+++ b/components/DocumentList.vue
@@ -24,6 +24,7 @@ const props = defineProps<{
   pending: boolean;
   useDailyPodcastView?: boolean | undefined;
   showMessageToMobileUsers?: boolean | undefined;
+  origin?: string;
 }>();
 
 const convertModels = (models: IAllDocumentModels[]) => {
@@ -93,6 +94,7 @@ const playItem = (item: TrackModel, group: IDiscoverableGroup) => {
   setQueue(
     items,
     items.findIndex((track) => track.id === item.id),
+    props.origin,
   );
 };
 const { device } = UAParser(navigator.userAgent);

--- a/components/EndlessDocumentList.vue
+++ b/components/EndlessDocumentList.vue
@@ -5,6 +5,7 @@ import { useInfiniteScroll } from "@vueuse/core";
 const props = defineProps<{
   load: (skip: number, take: number) => Promise<IAllDocumentModels[]>;
   useDailyPodcastView?: boolean | undefined;
+  origin?: string;
 }>();
 
 const list = ref<IAllDocumentModels[]>([]);
@@ -62,6 +63,7 @@ watch(reactiveDependencies(), async () => {
       :items="list"
       :pending="false"
       :use-daily-podcast-view="useDailyPodcastView"
+      :origin="origin"
     />
     <ul v-if="loadingMore">
       <li

--- a/components/TileItem.vue
+++ b/components/TileItem.vue
@@ -7,12 +7,18 @@ const props = defineProps<{
 }>();
 
 const { setQueue } = useNuxtApp().$mediaPlayer;
+const origin = () => `Tile`;
 
 function playTrack() {
   if (!props.item.track) return;
   if (props.item.lastPositionInMs)
-    setQueue([props.item.track], 0, props.item.lastPositionInMs / 1000);
-  else setQueue([props.item.track]);
+    setQueue(
+      [props.item.track],
+      0,
+      origin(),
+      props.item.lastPositionInMs / 1000,
+    );
+  else setQueue([props.item.track], 0, origin());
   // ToDo: load linked album (from showAllLink) and add remaining items to the queue
 }
 
@@ -21,7 +27,7 @@ async function shufflePodcast() {
     const tracks = await new PodcastApi().podcastIdShuffleGet({
       id: props.item.shufflePodcastId,
     });
-    setQueue(tracks);
+    setQueue(tracks, 0, origin());
   }
 }
 </script>

--- a/components/TileItem.vue
+++ b/components/TileItem.vue
@@ -7,18 +7,13 @@ const props = defineProps<{
 }>();
 
 const { setQueue } = useNuxtApp().$mediaPlayer;
-const origin = () => `Tile`;
+const origin = "Tile";
 
 function playTrack() {
   if (!props.item.track) return;
   if (props.item.lastPositionInMs)
-    setQueue(
-      [props.item.track],
-      0,
-      origin(),
-      props.item.lastPositionInMs / 1000,
-    );
-  else setQueue([props.item.track], 0, origin());
+    setQueue([props.item.track], 0, origin, props.item.lastPositionInMs / 1000);
+  else setQueue([props.item.track], 0, origin);
   // ToDo: load linked album (from showAllLink) and add remaining items to the queue
 }
 
@@ -27,7 +22,7 @@ async function shufflePodcast() {
     const tracks = await new PodcastApi().podcastIdShuffleGet({
       id: props.item.shufflePodcastId,
     });
-    setQueue(tracks, 0, origin());
+    setQueue(tracks, 0, origin);
   }
 }
 </script>
@@ -84,7 +79,7 @@ async function shufflePodcast() {
             class="aspect-square p-1 text-xl text-black-1"
           />
         </button>
-        <TrackMenu :track="item.track" class="ml-auto" :origin="origin()" />
+        <TrackMenu :track="item.track" class="ml-auto" :origin="origin" />
       </div>
     </div>
   </div>

--- a/components/TileItem.vue
+++ b/components/TileItem.vue
@@ -84,7 +84,7 @@ async function shufflePodcast() {
             class="aspect-square p-1 text-xl text-black-1"
           />
         </button>
-        <TrackMenu :track="item.track" class="ml-auto" />
+        <TrackMenu :track="item.track" class="ml-auto" :origin="origin()" />
       </div>
     </div>
   </div>

--- a/components/media-player/MediaPlayerOpen.vue
+++ b/components/media-player/MediaPlayerOpen.vue
@@ -224,7 +224,7 @@ useDraggable(queueListElement, queue, {
       <ul ref="queueListElement" class="px-3 pb-3">
         <li
           v-for="(item, i) in queue"
-          :key="item.trackModel.id"
+          :key="item.track.id"
           @click="queue.index = i"
         >
           <div
@@ -236,19 +236,19 @@ useDraggable(queueListElement, queue, {
             class="flex cursor-row-resize justify-between gap-2 rounded-xl px-3 py-2 transition-all duration-500 ease-out hover:bg-background-2"
           >
             <div class="truncate">
-              <div>{{ trackTitleField(item.trackModel) }}</div>
+              <div>{{ trackTitleField(item.track) }}</div>
               <div
                 class="text-sm"
                 :class="isCurrentTrack(i) ? 'text-black-2' : 'text-label-2'"
               >
                 <span>
-                  {{ trackSubtitleField(item.trackModel) }}
+                  {{ trackSubtitleField(item.track) }}
                 </span>
               </div>
             </div>
 
             <div class="flex items-center justify-between gap-2">
-              <TrackMenu :track="item.trackModel" />
+              <TrackMenu :track="item.track" />
               <NuxtIcon
                 v-if="isCurrentTrack(i) && status !== MediaPlayerStatus.Stopped"
                 name="icon.playing.animation"

--- a/components/media-player/MediaPlayerOpen.vue
+++ b/components/media-player/MediaPlayerOpen.vue
@@ -248,7 +248,7 @@ useDraggable(queueListElement, queue, {
             </div>
 
             <div class="flex items-center justify-between gap-2">
-              <TrackMenu :track="item.track" />
+              <TrackMenu :track="item.track" :origin="item.originView" />
               <NuxtIcon
                 v-if="isCurrentTrack(i) && status !== MediaPlayerStatus.Stopped"
                 name="icon.playing.animation"

--- a/components/media-player/MediaPlayerOpen.vue
+++ b/components/media-player/MediaPlayerOpen.vue
@@ -17,6 +17,7 @@ const {
   play,
   pause,
   currentTrack,
+  currentEnrichedTrack,
   currentPosition,
   currentTrackDuration,
   isLoading,
@@ -176,6 +177,7 @@ useDraggable(queueListElement, queue, {
           <TrackMenu
             v-if="currentTrack"
             :track="currentTrack"
+            :origin="currentEnrichedTrack?.originView"
             button-class="rounded-full border border-label-separator p-1.5"
           ></TrackMenu>
         </div>

--- a/components/media-player/MediaPlayerOpen.vue
+++ b/components/media-player/MediaPlayerOpen.vue
@@ -222,7 +222,11 @@ useDraggable(queueListElement, queue, {
         </div>
       </div>
       <ul ref="queueListElement" class="px-3 pb-3">
-        <li v-for="(item, i) in queue" :key="item.id" @click="queue.index = i">
+        <li
+          v-for="(item, i) in queue"
+          :key="item.trackModel.id"
+          @click="queue.index = i"
+        >
           <div
             :class="{
               'bg-tint text-black-1 hover:bg-tint': isCurrentTrack(i),
@@ -232,19 +236,19 @@ useDraggable(queueListElement, queue, {
             class="flex cursor-row-resize justify-between gap-2 rounded-xl px-3 py-2 transition-all duration-500 ease-out hover:bg-background-2"
           >
             <div class="truncate">
-              <div>{{ trackTitleField(item) }}</div>
+              <div>{{ trackTitleField(item.trackModel) }}</div>
               <div
                 class="text-sm"
                 :class="isCurrentTrack(i) ? 'text-black-2' : 'text-label-2'"
               >
                 <span>
-                  {{ trackSubtitleField(item) }}
+                  {{ trackSubtitleField(item.trackModel) }}
                 </span>
               </div>
             </div>
 
             <div class="flex items-center justify-between gap-2">
-              <TrackMenu :track="item" />
+              <TrackMenu :track="item.trackModel" />
               <NuxtIcon
                 v-if="isCurrentTrack(i) && status !== MediaPlayerStatus.Stopped"
                 name="icon.playing.animation"

--- a/components/track/TrackItem.vue
+++ b/components/track/TrackItem.vue
@@ -14,6 +14,7 @@ const props = withDefaults(
     highlight?: Highlighting | undefined;
     addDropdownItems?: (items: DropdownMenuItem[], track: TrackModel) => void;
     isAlbumKnown?: boolean;
+    origin?: string;
   }>(),
   {
     isAlbumKnown: false,
@@ -199,7 +200,7 @@ const selectedTrack: Ref<TrackModel | null> = ref(null);
           class="rounded-full p-2 opacity-0 hover:bg-label-separator hover:opacity-100 group-hover:opacity-100 group-focus:opacity-100"
           :aria-label="t('track.dropdown.play-next')"
           :title="t('track.dropdown.play-next')"
-          @click="addNext(track)"
+          @click="addNext(track, props.origin)"
           @click.stop
         >
           <NuxtIcon name="icon.play" class="text-2xl" />
@@ -211,6 +212,7 @@ const selectedTrack: Ref<TrackModel | null> = ref(null);
             (isPlaying ? 'text-black-1 hover:text-black-1' : 'text-label-1')
           "
           :add-dropdown-items="props.addDropdownItems"
+          :origin="props.origin"
         />
       </div>
     </div>

--- a/components/track/TrackList.vue
+++ b/components/track/TrackList.vue
@@ -57,6 +57,7 @@ const isTrackTypeKnown = () => {
         :show-thumbnail="showThumbnails"
         :add-dropdown-items="props.addDropdownItems"
         :is-album-known="props.albumIsKnown"
+        :origin="props.origin"
         @play-track="setQueue(tracks, i, props.origin)"
       >
       </TrackItem>

--- a/components/track/TrackList.vue
+++ b/components/track/TrackList.vue
@@ -10,12 +10,14 @@ const props = withDefaults(
     albumIsKnown?: boolean;
     showThumbnails?: boolean;
     addDropdownItems?: (items: DropdownMenuItem[], track: TrackModel) => void;
+    origin?: string;
   }>(),
   {
     skeletonCount: 5,
     addDropdownItems: undefined,
     trackTypeIsKnown: undefined,
     albumIsKnown: false,
+    origin: "",
   },
 );
 
@@ -55,7 +57,7 @@ const isTrackTypeKnown = () => {
         :show-thumbnail="showThumbnails"
         :add-dropdown-items="props.addDropdownItems"
         :is-album-known="props.albumIsKnown"
-        @play-track="setQueue(tracks, i)"
+        @play-track="setQueue(tracks, i, props.origin)"
       >
       </TrackItem>
     </template>

--- a/components/track/TrackMenu.vue
+++ b/components/track/TrackMenu.vue
@@ -15,6 +15,7 @@ const props = withDefaults(
     track: TrackModel;
     buttonClass?: string;
     addDropdownItems?: (items: DropdownMenuItem[], track: TrackModel) => void;
+    origin?: string;
   }>(),
   {
     buttonClass: "",
@@ -35,12 +36,12 @@ const dropdownMenuItemsForTrack = (track: TrackModel) => {
   items.push({
     icon: "icon.play",
     text: t("track.dropdown.play-next"),
-    clickFunction: () => addNext(track),
+    clickFunction: () => addNext(track, props.origin),
   });
   items.push({
     icon: "icon.queue",
     text: t("track.dropdown.add-to-queue"),
-    clickFunction: () => addToQueue(track),
+    clickFunction: () => addToQueue(track, props.origin),
   });
 
   if (track?.meta?.parent?.id) {

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -11,5 +11,6 @@ const { data: models, pending } = useDiscover({});
     :pending="pending"
     class="mt-6 lg:mt-12"
     show-message-to-mobile-users
+    origin="ExploreNewest"
   ></DocumentList>
 </template>

--- a/pages/playlist/contributor/[id]/index.vue
+++ b/pages/playlist/contributor/[id]/index.vue
@@ -82,6 +82,6 @@ async function load(skip: number, take: number) {
       </template>
     </TrackCollectionHeader>
 
-    <EndlessDocumentList :load="load" />
+    <EndlessDocumentList :load="load" :origin="origin()" />
   </div>
 </template>

--- a/pages/playlist/contributor/[id]/index.vue
+++ b/pages/playlist/contributor/[id]/index.vue
@@ -11,14 +11,14 @@ let tracks: TrackModel[] = [];
 const api = new ContributorApi();
 
 toolbarTitleStore().setReactiveToolbarTitle(() => t("nav.contributor"));
-const origin = () => `Contributor|${contributorId}`;
+const origin = computed(() => `Contributor|${contributorId}`);
 
 useHead({
   title: contributor.value?.name || "",
 });
 const onPressPlay = () => {
   if (tracks.length > 0) {
-    setQueue(tracks, 0, origin());
+    setQueue(tracks, 0, origin.value);
   }
 };
 const onPressShuffle = async () => {
@@ -27,7 +27,7 @@ const onPressShuffle = async () => {
       .value;
 
     if (shuffledTracks) {
-      setQueue(shuffledTracks, 0, origin());
+      setQueue(shuffledTracks, 0, origin.value);
     }
   } catch (e) {
     // TODO: Show an error message to the user
@@ -82,6 +82,6 @@ async function load(skip: number, take: number) {
       </template>
     </TrackCollectionHeader>
 
-    <EndlessDocumentList :load="load" :origin="origin()" />
+    <EndlessDocumentList :load="load" :origin="origin" />
   </div>
 </template>

--- a/pages/playlist/contributor/[id]/index.vue
+++ b/pages/playlist/contributor/[id]/index.vue
@@ -11,13 +11,14 @@ let tracks: TrackModel[] = [];
 const api = new ContributorApi();
 
 toolbarTitleStore().setReactiveToolbarTitle(() => t("nav.contributor"));
+const origin = () => `Contributor|${contributorId}`;
 
 useHead({
   title: contributor.value?.name || "",
 });
 const onPressPlay = () => {
   if (tracks.length > 0) {
-    setQueue(tracks);
+    setQueue(tracks, 0, origin());
   }
 };
 const onPressShuffle = async () => {
@@ -26,7 +27,7 @@ const onPressShuffle = async () => {
       .value;
 
     if (shuffledTracks) {
-      setQueue(shuffledTracks);
+      setQueue(shuffledTracks, 0, origin());
     }
   } catch (e) {
     // TODO: Show an error message to the user

--- a/pages/playlist/curated/[id]/index.vue
+++ b/pages/playlist/curated/[id]/index.vue
@@ -10,15 +10,16 @@ const { data: playlist } = useCuratedPlaylist({ id: playlistId });
 const { data: tracks, pending } = useCuratedPlaylistTracks({ id: playlistId });
 
 const { setQueueShuffled, setQueue } = useNuxtApp().$mediaPlayer;
+const origin = () => `CuratedPlaylist|${playlistId}|${playlist.value?.title}`;
 
 const onPressPlay = () => {
   if (tracks.value) {
-    setQueue(tracks.value);
+    setQueue(tracks.value, 0, origin());
   }
 };
 function shuffle() {
   if (tracks.value) {
-    setQueueShuffled(tracks.value);
+    setQueueShuffled(tracks.value, origin());
     $appInsights.event("Shuffle Playlist", { playlistId });
   }
 }
@@ -72,6 +73,7 @@ onBeforeMount(() => {
         :skeleton-count="10"
         :show-skeleton="pending"
         :tracks="tracks"
+        :origin="origin()"
       />
     </div>
   </div>

--- a/pages/playlist/curated/[id]/index.vue
+++ b/pages/playlist/curated/[id]/index.vue
@@ -10,16 +10,18 @@ const { data: playlist } = useCuratedPlaylist({ id: playlistId });
 const { data: tracks, pending } = useCuratedPlaylistTracks({ id: playlistId });
 
 const { setQueueShuffled, setQueue } = useNuxtApp().$mediaPlayer;
-const origin = () => `CuratedPlaylist|${playlistId}|${playlist.value?.title}`;
+const origin = computed(
+  () => `CuratedPlaylist|${playlistId}|${playlist.value?.title}`,
+);
 
 const onPressPlay = () => {
   if (tracks.value) {
-    setQueue(tracks.value, 0, origin());
+    setQueue(tracks.value, 0, origin.value);
   }
 };
 function shuffle() {
   if (tracks.value) {
-    setQueueShuffled(tracks.value, origin());
+    setQueueShuffled(tracks.value, origin.value);
     $appInsights.event("Shuffle Playlist", { playlistId });
   }
 }
@@ -73,7 +75,7 @@ onBeforeMount(() => {
         :skeleton-count="10"
         :show-skeleton="pending"
         :tracks="tracks"
-        :origin="origin()"
+        :origin="origin"
       />
     </div>
   </div>

--- a/pages/search/[[term]].vue
+++ b/pages/search/[[term]].vue
@@ -143,7 +143,7 @@ function playTrack(item: TrackModel) {
   );
   const index = tracks.findIndex((x: TrackModel) => x === item);
   if (highlighting && highlighting.startPositionInSeconds) {
-    setQueue(tracks, index, highlighting.startPositionInSeconds);
+    setQueue(tracks, index, "", highlighting.startPositionInSeconds);
   } else {
     setQueue(tracks, index);
   }

--- a/plugins/4.mediaPlayer.ts
+++ b/plugins/4.mediaPlayer.ts
@@ -68,24 +68,24 @@ export default defineNuxtPlugin((_) => {
               }
             },
             (play: PlayMeasurement) => {
-              const file = defaultFileForTrack(track);
+              const file = defaultFileForTrack(track.track);
               const trackLength = file?.duration || 0;
               const eventValues = {
                 ...play,
                 personId: userData.personId,
-                trackId: track.id,
+                trackId: track.track.id,
                 percentage:
                   trackLength > 0
                     ? (play.uniqueSecondsListened * 100) / trackLength
                     : 0,
                 trackLength,
-                typeOfTrack: track.subtype,
+                typeOfTrack: track.track.subtype,
                 availability: ResourceAvailability.Remote,
-                albumId: track.parentId,
-                tags: track.tags,
+                albumId: track.track.parentId,
+                tags: track.track.tags,
                 sentAfterStartup: false,
-                language: track.language,
-                playbackOrigin: "",
+                language: track.track.language,
+                playbackOrigin: track.originView,
                 adjustedPlaybackSpeed: 1,
                 client: runtimeConfig.public.systemName,
               };

--- a/plugins/mediaPlayer/EnrichedTrackModel.ts
+++ b/plugins/mediaPlayer/EnrichedTrackModel.ts
@@ -1,9 +1,12 @@
 import type { TrackModel } from "@bcc-code/bmm-sdk-fetch";
 
 export default class EnrichedTrackModel {
-  constructor(trackModel: TrackModel) {
+  constructor(trackModel: TrackModel, originViewModel: string) {
     this.track = trackModel;
+    this.originViewModel = originViewModel;
   }
 
   track: TrackModel;
+
+  originViewModel: string;
 }

--- a/plugins/mediaPlayer/EnrichedTrackModel.ts
+++ b/plugins/mediaPlayer/EnrichedTrackModel.ts
@@ -3,10 +3,10 @@ import type { TrackModel } from "@bcc-code/bmm-sdk-fetch";
 export default class EnrichedTrackModel {
   constructor(trackModel: TrackModel, originViewModel: string) {
     this.track = trackModel;
-    this.originViewModel = originViewModel;
+    this.originView = originViewModel;
   }
 
   track: TrackModel;
 
-  originViewModel: string;
+  originView: string;
 }

--- a/plugins/mediaPlayer/EnrichedTrackModel.ts
+++ b/plugins/mediaPlayer/EnrichedTrackModel.ts
@@ -1,0 +1,9 @@
+import type { TrackModel } from "@bcc-code/bmm-sdk-fetch";
+
+export default class EnrichedTrackModel {
+  constructor(trackModel: TrackModel) {
+    this.trackModel = trackModel;
+  }
+
+  trackModel: TrackModel;
+}

--- a/plugins/mediaPlayer/EnrichedTrackModel.ts
+++ b/plugins/mediaPlayer/EnrichedTrackModel.ts
@@ -2,8 +2,8 @@ import type { TrackModel } from "@bcc-code/bmm-sdk-fetch";
 
 export default class EnrichedTrackModel {
   constructor(trackModel: TrackModel) {
-    this.trackModel = trackModel;
+    this.track = trackModel;
   }
 
-  trackModel: TrackModel;
+  track: TrackModel;
 }

--- a/plugins/mediaPlayer/Queue.spec.ts
+++ b/plugins/mediaPlayer/Queue.spec.ts
@@ -19,7 +19,7 @@ function track(id: number) {
     language: "nb",
     meta: {},
   };
-  return new EnrichedTrackModel(t);
+  return new EnrichedTrackModel(t, "");
 }
 
 describe("plugin mediaPlayer Queue", () => {

--- a/plugins/mediaPlayer/Queue.spec.ts
+++ b/plugins/mediaPlayer/Queue.spec.ts
@@ -4,6 +4,7 @@ import { describe, it, expect } from "vitest";
 import { flushPromises } from "@vue/test-utils";
 import type { TrackModel } from "@bcc-code/bmm-sdk-fetch";
 import Queue from "./Queue";
+import EnrichedTrackModel from "./EnrichedTrackModel";
 
 const now = new Date();
 function track(id: number) {
@@ -18,7 +19,7 @@ function track(id: number) {
     language: "nb",
     meta: {},
   };
-  return t;
+  return new EnrichedTrackModel(t);
 }
 
 describe("plugin mediaPlayer Queue", () => {
@@ -69,7 +70,7 @@ describe("plugin mediaPlayer Queue", () => {
       expect(q.isShuffled).equal(false);
       expect(q.index).equal(0);
       expect(q.currentTrack).toBeDefined();
-      expect(q.currentTrack!.id).equal(1);
+      expect(q.currentTrack!.trackModel.id).equal(1);
     });
 
     it("is unshuffled and has an index of 1 on non-empty initialization with index of 1", () => {
@@ -80,7 +81,7 @@ describe("plugin mediaPlayer Queue", () => {
       expect(q.isShuffled).equal(false);
       expect(q.index).equal(1);
       expect(q.currentTrack).toBeDefined();
-      expect(q.currentTrack!.id).equal(2);
+      expect(q.currentTrack!.trackModel.id).equal(2);
     });
 
     it("is unshuffled and has an index of 0 on non-empty initialization with index of -99", () => {
@@ -91,7 +92,7 @@ describe("plugin mediaPlayer Queue", () => {
       expect(q.isShuffled).equal(false);
       expect(q.index).equal(0);
       expect(q.currentTrack).toBeDefined();
-      expect(q.currentTrack!.id).equal(1);
+      expect(q.currentTrack!.trackModel.id).equal(1);
     });
 
     it("is unshuffled and has an index of the highest element on non-empty initialization with index of 99 (too high)", () => {
@@ -102,7 +103,7 @@ describe("plugin mediaPlayer Queue", () => {
       expect(q.isShuffled).equal(false);
       expect(q.index).equal(2);
       expect(q.currentTrack).toBeDefined();
-      expect(q.currentTrack!.id).equal(3);
+      expect(q.currentTrack!.trackModel.id).equal(3);
     });
   });
 
@@ -117,7 +118,7 @@ describe("plugin mediaPlayer Queue", () => {
         q.shuffle();
 
         // Assert
-        expect(q[2]?.id).not.eq(2);
+        expect(q[2]?.trackModel.id).not.eq(2);
         expect(q.isShuffled).eq(true);
       },
       { retry: 100 },
@@ -134,7 +135,7 @@ describe("plugin mediaPlayer Queue", () => {
         q.unshuffle();
 
         // Assert
-        expect(q[2]?.id).eq(2);
+        expect(q[2]?.trackModel.id).eq(2);
         expect(q.isShuffled).eq(false);
       },
       { repeats: 100 },
@@ -151,7 +152,7 @@ describe("plugin mediaPlayer Queue", () => {
           indexes.push(v);
         },
       );
-      const tracks: (TrackModel | undefined)[] = [];
+      const tracks: (EnrichedTrackModel | undefined)[] = [];
       watch(
         () => qObject.value?.currentTrack,
         (v) => {
@@ -189,7 +190,7 @@ describe("plugin mediaPlayer Queue", () => {
           indexes.push(v);
         },
       );
-      const tracks: (TrackModel | undefined)[] = [];
+      const tracks: (EnrichedTrackModel | undefined)[] = [];
       watch(
         () => qObject.value?.currentTrack,
         (v) => {
@@ -223,7 +224,7 @@ describe("plugin mediaPlayer Queue", () => {
           indexes.push(v);
         },
       );
-      const tracks: (TrackModel | undefined)[] = [];
+      const tracks: (EnrichedTrackModel | undefined)[] = [];
       watch(
         () => qObject.value?.currentTrack,
         (v) => {
@@ -257,7 +258,7 @@ describe("plugin mediaPlayer Queue", () => {
           indexes.push(v);
         },
       );
-      const tracks: (TrackModel | undefined)[] = [];
+      const tracks: (EnrichedTrackModel | undefined)[] = [];
       watch(
         () => qObject.value?.currentTrack,
         (v) => {
@@ -291,7 +292,7 @@ describe("plugin mediaPlayer Queue", () => {
           indexes.push(v);
         },
       );
-      const tracks: (TrackModel | undefined)[] = [];
+      const tracks: (EnrichedTrackModel | undefined)[] = [];
       watch(
         () => qObject.value?.currentTrack,
         (v) => {
@@ -325,7 +326,7 @@ describe("plugin mediaPlayer Queue", () => {
           indexes.push(v);
         },
       );
-      const tracks: (TrackModel | undefined)[] = [];
+      const tracks: (EnrichedTrackModel | undefined)[] = [];
       watch(
         () => qObject.value?.currentTrack,
         (v) => {
@@ -382,7 +383,7 @@ describe("plugin mediaPlayer Queue", () => {
     it("reordering doesn't change the current track", async () => {
       // Arrange
       const qObject = ref<Queue | undefined>();
-      const changes: (TrackModel | undefined)[] = [];
+      const changes: (EnrichedTrackModel | undefined)[] = [];
 
       qObject.value = new Queue(
         new Array(10).fill(0).map((_, i) => track(i)),

--- a/plugins/mediaPlayer/Queue.spec.ts
+++ b/plugins/mediaPlayer/Queue.spec.ts
@@ -70,7 +70,7 @@ describe("plugin mediaPlayer Queue", () => {
       expect(q.isShuffled).equal(false);
       expect(q.index).equal(0);
       expect(q.currentTrack).toBeDefined();
-      expect(q.currentTrack!.trackModel.id).equal(1);
+      expect(q.currentTrack!.track.id).equal(1);
     });
 
     it("is unshuffled and has an index of 1 on non-empty initialization with index of 1", () => {
@@ -81,7 +81,7 @@ describe("plugin mediaPlayer Queue", () => {
       expect(q.isShuffled).equal(false);
       expect(q.index).equal(1);
       expect(q.currentTrack).toBeDefined();
-      expect(q.currentTrack!.trackModel.id).equal(2);
+      expect(q.currentTrack!.track.id).equal(2);
     });
 
     it("is unshuffled and has an index of 0 on non-empty initialization with index of -99", () => {
@@ -92,7 +92,7 @@ describe("plugin mediaPlayer Queue", () => {
       expect(q.isShuffled).equal(false);
       expect(q.index).equal(0);
       expect(q.currentTrack).toBeDefined();
-      expect(q.currentTrack!.trackModel.id).equal(1);
+      expect(q.currentTrack!.track.id).equal(1);
     });
 
     it("is unshuffled and has an index of the highest element on non-empty initialization with index of 99 (too high)", () => {
@@ -103,7 +103,7 @@ describe("plugin mediaPlayer Queue", () => {
       expect(q.isShuffled).equal(false);
       expect(q.index).equal(2);
       expect(q.currentTrack).toBeDefined();
-      expect(q.currentTrack!.trackModel.id).equal(3);
+      expect(q.currentTrack!.track.id).equal(3);
     });
   });
 
@@ -118,7 +118,7 @@ describe("plugin mediaPlayer Queue", () => {
         q.shuffle();
 
         // Assert
-        expect(q[2]?.trackModel.id).not.eq(2);
+        expect(q[2]?.track.id).not.eq(2);
         expect(q.isShuffled).eq(true);
       },
       { retry: 100 },
@@ -135,7 +135,7 @@ describe("plugin mediaPlayer Queue", () => {
         q.unshuffle();
 
         // Assert
-        expect(q[2]?.trackModel.id).eq(2);
+        expect(q[2]?.track.id).eq(2);
         expect(q.isShuffled).eq(false);
       },
       { repeats: 100 },

--- a/plugins/mediaPlayer/Queue.ts
+++ b/plugins/mediaPlayer/Queue.ts
@@ -1,6 +1,6 @@
-import type { TrackModel } from "@bcc-code/bmm-sdk-fetch";
+import type EnrichedTrackModel from "./EnrichedTrackModel";
 
-export default class Queue extends Array<TrackModel> {
+export default class Queue extends Array<EnrichedTrackModel> {
   public isShuffled = false;
 
   private i = 0;
@@ -24,15 +24,15 @@ export default class Queue extends Array<TrackModel> {
     this.cT = this[this.i];
   }
 
-  private cT: TrackModel | undefined;
+  private cT: EnrichedTrackModel | undefined;
 
   public get currentTrack() {
     return this.cT;
   }
 
-  private sortedArray: Array<TrackModel> | undefined;
+  private sortedArray: Array<EnrichedTrackModel> | undefined;
 
-  constructor(data: TrackModel[] = [], index = -1) {
+  constructor(data: EnrichedTrackModel[] = [], index = -1) {
     super();
 
     if (Array.isArray(data)) {

--- a/plugins/mediaPlayer/mediaPlayer.spec.ts
+++ b/plugins/mediaPlayer/mediaPlayer.spec.ts
@@ -14,6 +14,7 @@ import {
   MediaPlayerStatus,
   RepeatStatus,
 } from "./mediaPlayer";
+import EnrichedTrackModel from "./EnrichedTrackModel";
 
 vi.mock("./Queue", async (importOriginal) => {
   const { default: Mod } = (await importOriginal()) as any;
@@ -40,6 +41,10 @@ function track(id: number) {
     meta: {},
   };
   return t;
+}
+
+function enrichedTrack(id: number) {
+  return new EnrichedTrackModel(track(id));
 }
 
 const userData: IUserData = { personId: null, age: null, os: "Test" };
@@ -593,7 +598,7 @@ describe("plugin mediaPlayer MediaTrack", () => {
       MockedQueue.mockClear();
       const oldQueue = mediaPlayer.value.queue;
 
-      const queues: TrackModel[][] = [];
+      const queues: EnrichedTrackModel[][] = [];
       watch(
         () => mediaPlayer.value.queue,
         (v) => {
@@ -662,9 +667,9 @@ describe("plugin mediaPlayer MediaTrack", () => {
         // Assert
         expect(mediaPlayer.value.queue).length(3);
         expect(mediaPlayer.value.queue.index).eq(0);
-        expect(mediaPlayer.value.queue[0]?.id).eq(2);
-        expect(mediaPlayer.value.queue[1]?.id).eq(1);
-        expect(mediaPlayer.value.queue[2]?.id).eq(3);
+        expect(mediaPlayer.value.queue[0]?.trackModel.id).eq(2);
+        expect(mediaPlayer.value.queue[1]?.trackModel.id).eq(1);
+        expect(mediaPlayer.value.queue[2]?.trackModel.id).eq(3);
       },
       { retry: 100 },
     );
@@ -694,7 +699,11 @@ describe("plugin mediaPlayer MediaTrack", () => {
       // Assert
       expect(MockedMediaTrack).toHaveBeenCalledTimes(0);
       expect(currentTracks).eql([]);
-      expect(mediaPlayer.value.queue).eql([track(1), track(2), track(3)]);
+      expect(mediaPlayer.value.queue).eql([
+        enrichedTrack(1),
+        enrichedTrack(2),
+        enrichedTrack(3),
+      ]);
     });
 
     it("adds an element to the queue and start playing if queue is empty", async () => {
@@ -717,7 +726,7 @@ describe("plugin mediaPlayer MediaTrack", () => {
       // Assert
       expect(MockedMediaTrack).toHaveBeenCalledTimes(1);
       expect(currentTracks).eql([track(3)]);
-      expect(mediaPlayer.value.queue).eql([track(3)]);
+      expect(mediaPlayer.value.queue).eql([enrichedTrack(3)]);
     });
 
     it("adds an element to the queue and start playing if queue has finished playing", async () => {
@@ -747,7 +756,11 @@ describe("plugin mediaPlayer MediaTrack", () => {
       // Assert
       expect(MockedMediaTrack).toHaveBeenCalledTimes(1);
       expect(currentTracks).eql([track(3)]);
-      expect(mediaPlayer.value.queue).eql([track(1), track(2), track(3)]);
+      expect(mediaPlayer.value.queue).eql([
+        enrichedTrack(1),
+        enrichedTrack(2),
+        enrichedTrack(3),
+      ]);
     });
   });
 
@@ -775,7 +788,11 @@ describe("plugin mediaPlayer MediaTrack", () => {
       // Assert
       expect(MockedMediaTrack).toHaveBeenCalledTimes(0);
       expect(currentTracks).eql([]);
-      expect(mediaPlayer.value.queue).eql([track(1), track(2), track(3)]);
+      expect(mediaPlayer.value.queue).eql([
+        enrichedTrack(1),
+        enrichedTrack(2),
+        enrichedTrack(3),
+      ]);
     });
 
     it("adds an element to the queue next to the current element if another track has been added and current element is set", async () => {
@@ -792,10 +809,10 @@ describe("plugin mediaPlayer MediaTrack", () => {
 
       // Assert
       expect(mediaPlayer.value.queue).eql([
-        track(1),
-        track(2),
-        track(3),
-        track(4),
+        enrichedTrack(1),
+        enrichedTrack(2),
+        enrichedTrack(3),
+        enrichedTrack(4),
       ]);
     });
 
@@ -819,7 +836,7 @@ describe("plugin mediaPlayer MediaTrack", () => {
       // Assert
       expect(MockedMediaTrack).toHaveBeenCalledTimes(1);
       expect(currentTracks).eql([track(3)]);
-      expect(mediaPlayer.value.queue).eql([track(3)]);
+      expect(mediaPlayer.value.queue).eql([enrichedTrack(3)]);
     });
 
     it("adds an element to the queue next to the current element and start playing if queue has finished playing", async () => {
@@ -849,7 +866,11 @@ describe("plugin mediaPlayer MediaTrack", () => {
       // Assert
       expect(MockedMediaTrack).toHaveBeenCalledTimes(1);
       expect(currentTracks).eql([track(3)]);
-      expect(mediaPlayer.value.queue).eql([track(1), track(2), track(3)]);
+      expect(mediaPlayer.value.queue).eql([
+        enrichedTrack(1),
+        enrichedTrack(2),
+        enrichedTrack(3),
+      ]);
     });
   });
 
@@ -1287,7 +1308,7 @@ describe("plugin mediaPlayer MediaTrack", () => {
         // Assert
         expect(queueValue).length(2);
         expect(queueValue[0]).not.eq(queueValue[1]);
-        expect(mediaPlayer.value.queue.currentTrack?.id).not.eq(4);
+        expect(mediaPlayer.value.queue.currentTrack?.trackModel.id).not.eq(4);
       });
 
       it("stopps playing after replacing the queue with an empty queue while playing", async () => {

--- a/plugins/mediaPlayer/mediaPlayer.spec.ts
+++ b/plugins/mediaPlayer/mediaPlayer.spec.ts
@@ -44,7 +44,7 @@ function track(id: number) {
 }
 
 function enrichedTrack(id: number) {
-  return new EnrichedTrackModel(track(id));
+  return new EnrichedTrackModel(track(id), "");
 }
 
 const userData: IUserData = { personId: null, age: null, os: "Test" };

--- a/plugins/mediaPlayer/mediaPlayer.spec.ts
+++ b/plugins/mediaPlayer/mediaPlayer.spec.ts
@@ -667,9 +667,9 @@ describe("plugin mediaPlayer MediaTrack", () => {
         // Assert
         expect(mediaPlayer.value.queue).length(3);
         expect(mediaPlayer.value.queue.index).eq(0);
-        expect(mediaPlayer.value.queue[0]?.trackModel.id).eq(2);
-        expect(mediaPlayer.value.queue[1]?.trackModel.id).eq(1);
-        expect(mediaPlayer.value.queue[2]?.trackModel.id).eq(3);
+        expect(mediaPlayer.value.queue[0]?.track.id).eq(2);
+        expect(mediaPlayer.value.queue[1]?.track.id).eq(1);
+        expect(mediaPlayer.value.queue[2]?.track.id).eq(3);
       },
       { retry: 100 },
     );
@@ -1308,7 +1308,7 @@ describe("plugin mediaPlayer MediaTrack", () => {
         // Assert
         expect(queueValue).length(2);
         expect(queueValue[0]).not.eq(queueValue[1]);
-        expect(mediaPlayer.value.queue.currentTrack?.trackModel.id).not.eq(4);
+        expect(mediaPlayer.value.queue.currentTrack?.track.id).not.eq(4);
       });
 
       it("stopps playing after replacing the queue with an empty queue while playing", async () => {

--- a/plugins/mediaPlayer/mediaPlayer.ts
+++ b/plugins/mediaPlayer/mediaPlayer.ts
@@ -53,7 +53,7 @@ export interface MediaPlayer {
 export const seekOffset = 15;
 
 export const initMediaPlayer = (
-  createMediaTrack: (src: string, track: TrackModel) => MediaTrack,
+  createMediaTrack: (src: string, track: EnrichedTrackModel) => MediaTrack,
   appInsights: AppInsights,
   user: IUserData,
 ): MediaPlayer => {
@@ -94,7 +94,7 @@ export const initMediaPlayer = (
       url = `${url}#t=${new Date(nextStartPosition * 1000).toISOString().slice(11, 19)}`;
       nextStartPosition = 0;
     }
-    activeMedia.value = createMediaTrack(url, track.track);
+    activeMedia.value = createMediaTrack(url, track);
     activeMedia.value.setVolume(volume.value);
     activeMedia.value.registerSource();
     activeMedia.value.registerEvents();

--- a/plugins/mediaPlayer/mediaPlayer.ts
+++ b/plugins/mediaPlayer/mediaPlayer.ts
@@ -39,6 +39,7 @@ export interface MediaPlayer {
   setQueue: (
     queue: TrackModel[],
     index?: number,
+    origin?: string,
     startPosition?: number | null,
   ) => void;
   setQueueShuffled: (queue: TrackModel[]) => void;
@@ -233,19 +234,22 @@ export const initMediaPlayer = (
     }
   }
 
-  function addToQueue(track: TrackModel) {
-    queue.value.push({ track: { ...track } });
+  function addToQueue(track: TrackModel, origin: string = "") {
+    queue.value.push(new EnrichedTrackModel({ ...track }, origin));
     continuePlayingNextIfEnded();
   }
 
   function setQueue(
     _queue: TrackModel[],
     index = 0,
+    origin: string = "",
     startPosition: number | null = null,
   ): void {
     if (startPosition != null) nextStartPosition = startPosition;
     queue.value = new Queue(
-      _queue.map((track: TrackModel) => new EnrichedTrackModel({ ...track })),
+      _queue.map(
+        (track: TrackModel) => new EnrichedTrackModel({ ...track }, origin),
+      ),
       index,
     );
   }
@@ -257,7 +261,11 @@ export const initMediaPlayer = (
   }
 
   function addNext(track: TrackModel): void {
-    queue.value.splice(queue.value.index + 1, 0, { track: { ...track } });
+    queue.value.splice(
+      queue.value.index + 1,
+      0,
+      new EnrichedTrackModel({ ...track }, ""),
+    );
     continuePlayingNextIfEnded();
   }
 
@@ -266,7 +274,11 @@ export const initMediaPlayer = (
     stop();
 
     queue.value = new Queue(
-      queue.value.toSpliced(queue.value.index, 1, { track: { ...track } }),
+      queue.value.toSpliced(
+        queue.value.index,
+        1,
+        new EnrichedTrackModel({ ...track }, ""),
+      ),
       queue.value.index,
     );
   }

--- a/plugins/mediaPlayer/mediaPlayer.ts
+++ b/plugins/mediaPlayer/mediaPlayer.ts
@@ -87,12 +87,12 @@ export const initMediaPlayer = (
 
     activeMedia.value?.destroy();
 
-    let url = defaultFileForTrack(track.trackModel)?.url || "";
+    let url = defaultFileForTrack(track.track)?.url || "";
     if (nextStartPosition > 0) {
       url = `${url}#t=${new Date(nextStartPosition * 1000).toISOString().slice(11, 19)}`;
       nextStartPosition = 0;
     }
-    activeMedia.value = createMediaTrack(url, track.trackModel);
+    activeMedia.value = createMediaTrack(url, track.track);
     activeMedia.value.setVolume(volume.value);
     activeMedia.value.registerSource();
     activeMedia.value.registerEvents();
@@ -137,7 +137,7 @@ export const initMediaPlayer = (
     () => activeMedia.value?.ended,
     (ended) => {
       if (ended) {
-        const track = queue.value.currentTrack?.trackModel;
+        const track = queue.value.currentTrack?.track;
         if (track !== undefined && user.personId != null) {
           new StatisticsApi().statisticsListeningPost({
             listeningEvent: [
@@ -155,7 +155,7 @@ export const initMediaPlayer = (
           });
 
           appInsights.event("track completed", {
-            trackId: queue.value.currentTrack?.trackModel.id,
+            trackId: queue.value.currentTrack?.track.id,
             duration: activeMedia.value?.position,
           });
         }
@@ -176,7 +176,7 @@ export const initMediaPlayer = (
       trackTimestampStart = new Date();
       if (appInsights.event) {
         appInsights.event("track playback started", {
-          trackId: queue.value.currentTrack?.trackModel.id,
+          trackId: queue.value.currentTrack?.track.id,
         });
       }
     }
@@ -234,7 +234,7 @@ export const initMediaPlayer = (
   }
 
   function addToQueue(track: TrackModel) {
-    queue.value.push({ trackModel: { ...track } });
+    queue.value.push({ track: { ...track } });
     continuePlayingNextIfEnded();
   }
 
@@ -257,7 +257,7 @@ export const initMediaPlayer = (
   }
 
   function addNext(track: TrackModel): void {
-    queue.value.splice(queue.value.index + 1, 0, { trackModel: { ...track } });
+    queue.value.splice(queue.value.index + 1, 0, { track: { ...track } });
     continuePlayingNextIfEnded();
   }
 
@@ -266,7 +266,7 @@ export const initMediaPlayer = (
     stop();
 
     queue.value = new Queue(
-      queue.value.toSpliced(queue.value.index, 1, { trackModel: { ...track } }),
+      queue.value.toSpliced(queue.value.index, 1, { track: { ...track } }),
       queue.value.index,
     );
   }
@@ -301,7 +301,7 @@ export const initMediaPlayer = (
     isLoading: computed(() => activeMedia.value?.loading || false),
     hasNext,
     hasPrevious,
-    currentTrack: computed(() => queue.value.currentTrack?.trackModel),
+    currentTrack: computed(() => queue.value.currentTrack?.track),
     currentPosition,
     currentTrackDuration: computed(() =>
       activeMedia.value ? activeMedia.value.duration : NaN,

--- a/plugins/mediaPlayer/mediaPlayer.ts
+++ b/plugins/mediaPlayer/mediaPlayer.ts
@@ -33,6 +33,7 @@ export interface MediaPlayer {
   hasPrevious: ComputedRef<Boolean>;
   queue: ComputedRef<UnwrapRef<Queue>>;
   currentTrack: ComputedRef<UnwrapRef<TrackModel> | undefined>;
+  currentEnrichedTrack: ComputedRef<UnwrapRef<EnrichedTrackModel> | undefined>;
   currentPosition: Ref<number>;
   currentTrackDuration: ComputedRef<number>;
   volume: Ref<number>;
@@ -314,6 +315,7 @@ export const initMediaPlayer = (
     hasNext,
     hasPrevious,
     currentTrack: computed(() => queue.value.currentTrack?.track),
+    currentEnrichedTrack: computed(() => queue.value.currentTrack),
     currentPosition,
     currentTrackDuration: computed(() =>
       activeMedia.value ? activeMedia.value.duration : NaN,

--- a/plugins/mediaPlayer/mediaPlayer.ts
+++ b/plugins/mediaPlayer/mediaPlayer.ts
@@ -42,9 +42,9 @@ export interface MediaPlayer {
     origin?: string,
     startPosition?: number | null,
   ) => void;
-  setQueueShuffled: (queue: TrackModel[]) => void;
-  addToQueue: (track: TrackModel) => void;
-  addNext: (track: TrackModel) => void;
+  setQueueShuffled: (queue: TrackModel[], origin?: string) => void;
+  addToQueue: (track: TrackModel, origin?: string) => void;
+  addNext: (track: TrackModel, origin?: string) => void;
   replaceCurrent: (track: TrackModel) => void;
   repeatStatus: Ref<RepeatStatus>;
 }
@@ -254,17 +254,17 @@ export const initMediaPlayer = (
     );
   }
 
-  function setQueueShuffled(newQueue: TrackModel[]): void {
+  function setQueueShuffled(newQueue: TrackModel[], origin: string = ""): void {
     const trackIndex = Math.floor(Math.random() * newQueue.length);
-    setQueue(newQueue, trackIndex);
+    setQueue(newQueue, trackIndex, origin);
     queue.value.shuffle();
   }
 
-  function addNext(track: TrackModel): void {
+  function addNext(track: TrackModel, origin: string = ""): void {
     queue.value.splice(
       queue.value.index + 1,
       0,
-      new EnrichedTrackModel({ ...track }, ""),
+      new EnrichedTrackModel({ ...track }, origin),
     );
     continuePlayingNextIfEnded();
   }


### PR DESCRIPTION
So far this information has mainly been used for Analytics purposes. But we also use it to determine which are "Your top playlists" and we're getting reports about people listening to Daily Mix a lot, but not seeing it in their top playlists.

This PR creates the necessary infrastructure and sets the correct values for 3 of the 19 views. The other views can be added at a later time.