### PR TITLE
feat(player): smoothly animate player width when toggling open state

### DIFF
--- a/components/media-player/MediaPlayer.vue
+++ b/components/media-player/MediaPlayer.vue
@@ -21,13 +21,14 @@ defineShortcuts({
 
 <template>
   <div
-    class="shrink-0 transition-all duration-700 ease-out-expo"
+    class="shrink-0 transition-[width] duration-700 ease-out-expo"
     :class="{ 'w-[400px]': open, 'w-0': !open }"
   >
     <div
-      class="large-shadow group fixed bottom-1 right-0 z-30 flex w-[400px] max-w-full flex-col overflow-hidden rounded-2xl bg-background-1 transition-all duration-700 ease-out-expo sm:bottom-5 sm:right-5"
+      class="large-shadow group fixed bottom-1 right-0 z-30 flex w-[400px] max-w-full animate-[player-enter_200ms] flex-col overflow-hidden rounded-2xl bg-background-1 transition-all duration-700 ease-out-expo sm:bottom-5 sm:right-5"
       :style="{
         height: open ? 'calc(100vh - 6rem)' : '4.5rem',
+        'animation-timing-function': 'cubic-bezier(0.19, 1, 0.22, 1);',
       }"
     >
       <MediaPlayerClosed v-if="!open" @click.stop="open = !open" />

--- a/components/media-player/MediaPlayer.vue
+++ b/components/media-player/MediaPlayer.vue
@@ -20,7 +20,10 @@ defineShortcuts({
 </script>
 
 <template>
-  <div class="shrink-0" :class="{ 'w-[400px]': open }">
+  <div
+    class="shrink-0 transition-all duration-700 ease-out-expo"
+    :class="{ 'w-[400px]': open, 'w-0': !open }"
+  >
     <div
       class="large-shadow group fixed bottom-1 right-0 z-30 flex w-[400px] max-w-full flex-col overflow-hidden rounded-2xl bg-background-1 transition-all duration-700 ease-out-expo sm:bottom-5 sm:right-5"
       :style="{

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -26,14 +26,7 @@ const { queue } = useNuxtApp().$mediaPlayer;
           <slot />
         </Suspense>
 
-        <transition
-          enter-active-class="transition-all duration-200 ease-out"
-          enter-from-class="opacity-0 translate-y-2"
-          leave-active-class="transition-all duration-200 ease-out"
-          leave-to-class="opacity-0 translate-y-2"
-        >
-          <MediaPlayer v-if="queue.length > 0" />
-        </transition>
+        <MediaPlayer v-if="queue.length > 0" />
       </div>
       <DialogErrorDialog />
     </main>

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -32,6 +32,12 @@ const config: Partial<Config> = {
         tall: { raw: "(min-height: 700px)" },
         "x-tall": { raw: "(min-height: 800px)" },
       },
+      keyframes: {
+        "player-enter": {
+          "0%": { opacity: "0", transform: "translateY(1rem)" },
+          "100%": { opacity: "1", transform: "translateY(0)" },
+        },
+      },
     },
   },
   plugins: [


### PR DESCRIPTION
This is how it currently looks:

https://github.com/user-attachments/assets/6d73bc75-a968-46c2-8355-7bbeffc4fe96

With the transition it looks like this:

https://github.com/user-attachments/assets/b58471eb-ab9b-4aa2-8819-a469bd77a101

