### PR TITLE
feat(player): make marquee text fade out at the edges

### DIFF
--- a/components/TextMarquee.vue
+++ b/components/TextMarquee.vue
@@ -66,7 +66,11 @@ onUnmounted(() => {
 });
 </script>
 <template>
-  <div ref="elRef" class="relative flex w-fit">
+  <div
+    ref="elRef"
+    class="relative flex w-fit"
+    :data-marquee-enabled="contentIsTooLarge ? '' : null"
+  >
     <div
       ref="container"
       class="inline-block"

--- a/components/media-player/MediaPlayerOpen.vue
+++ b/components/media-player/MediaPlayerOpen.vue
@@ -72,7 +72,7 @@ useDraggable(queueListElement, queue, {
         />
       </div>
       <div class="flex flex-col gap-1 overflow-x-hidden whitespace-nowrap py-3">
-        <TextMarquee class="m-auto">
+        <TextMarquee class="mx-auto px-4">
           <h3
             v-if="currentTrack"
             class="text-lg font-semibold leading-tight"
@@ -84,7 +84,7 @@ useDraggable(queueListElement, queue, {
         <div
           class="overflow-x-hidden whitespace-nowrap text-base leading-snug text-label-2"
         >
-          <TextMarquee class="m-auto">
+          <TextMarquee class="mx-auto px-4">
             <span v-if="currentTrack" :title="trackSubtitleField(currentTrack)">
               {{ trackSubtitleField(currentTrack) }}
             </span>
@@ -272,3 +272,15 @@ useDraggable(queueListElement, queue, {
     </div>
   </div>
 </template>
+
+<style scoped>
+div:has(> [data-marquee-enabled]) {
+  mask-image: linear-gradient(
+    to right,
+    transparent 0%,
+    black 1rem,
+    black calc(100% - 1rem),
+    transparent 100%
+  );
+}
+</style>


### PR DESCRIPTION
This is how it currently looks:

https://github.com/user-attachments/assets/c853ccd4-9575-4c0d-90ba-4d29f9793529


This is after the change:

https://github.com/user-attachments/assets/ce77a724-885b-4f5a-86b6-0c25b62bddfe

