### PR TITLE
Replace shuffle algorithm

### DIFF
--- a/plugins/mediaPlayer/Queue.ts
+++ b/plugins/mediaPlayer/Queue.ts
@@ -52,11 +52,22 @@ export default class Queue extends Array<EnrichedTrackModel> {
     if (this.sortedArray) return;
 
     this.sortedArray = [...this];
-    this.sort((a, b) => {
-      if (a === this.currentTrack) return -1;
-      if (b === this.currentTrack) return 1;
-      return Math.random() - 0.5;
-    });
+    // Erase the queue…
+    this.splice(
+      // …from start…
+      0,
+      // …to end…
+      this.length,
+      // …replace the contents with:
+      // The current track in the first position…
+      ...(this.currentTrack ? [this.currentTrack] : []),
+      // …followed by all other tracks…
+      ...this.filter((track) => track !== this.currentTrack)
+        // …shuffled using Schwarzian Transform Shuffle
+        .map((track) => ({ track, ix: Math.random() }))
+        .sort(({ ix: a }, { ix: b }) => a - b)
+        .map(({ track }) => track),
+    );
     this.isShuffled = true;
 
     this.reevaluateIndex();


### PR DESCRIPTION
Previous algorithm had several issues. See #219 for the details.

New algorithm:
- Retains desired non-shuffle behaviour. The current track is kept at the top.
- Proper randomisation only dependent on the randomness of `Math.random()`, not on the pre-shuffle order of the track list.
- Proper stable comparison, the result of comparing two tracks A and B is the same at any point during the shuffle process.

I chose the Schwartzian Transform sort as basis for the shuffle algorithm. It is fairly easy to understand _why_ this algorithm is only dependent on the source of randomness. Compared to the BMM app's Fisher-Yates, which requires more mathematical proof that it is so, or the old implementation which required more mathematical proof that it is _not_ so.