### PR TITLE
Remove deprecated extension:

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,7 +1,6 @@
 {
   "recommendations": [
     "Vue.volar",
-    "Vue.vscode-typescript-vue-plugin",
     "ZixuanChen.vitest-explorer",
     "dbaeumer.vscode-eslint",
     "esbenp.prettier-vscode",


### PR DESCRIPTION
All its functionality has been replaced by `vue.volar`, which is already on the recommendations list anyway.