### PR TITLE
feat: add title beneath cover in album cards

### DIFF
--- a/components/ItemCard.vue
+++ b/components/ItemCard.vue
@@ -13,7 +13,9 @@ defineProps<{
 <template>
   <div :title="item.title || ''">
     <CoverImage :src="item.cover" class="w-full rounded-2xl" />
-    <span class="type-paragraph-3 mt-2 line-clamp-2 leading-snug text-label-1">
+    <span
+      class="type-paragraph-3 mt-2 line-clamp-1 w-full text-center leading-snug text-label-1"
+    >
       {{ item.title }}
     </span>
   </div>

--- a/components/ItemCard.vue
+++ b/components/ItemCard.vue
@@ -13,5 +13,8 @@ defineProps<{
 <template>
   <div :title="item.title || ''">
     <CoverImage :src="item.cover" class="w-full rounded-2xl" />
+    <span class="type-paragraph-3 mt-2 line-clamp-2 leading-snug text-label-1">
+      {{ item.title }}
+    </span>
   </div>
 </template>


### PR DESCRIPTION
This PR introduces a quick way to see the titles of each playlist / album / podcast.
I just put the title beneath the cover for now, as we don't have any design spec yet, as discussed in #451 

![CleanShot 2025-03-20 at 10 14 52](https://github.com/user-attachments/assets/3c5a6c4b-643d-4b95-8730-465b390f102f)

This does make the screen more "noisy", but that is an ok tradeoff in my opinion.