### PR TITLE
Add simple client-side caching

### DIFF
--- a/composables/album.ts
+++ b/composables/album.ts
@@ -8,12 +8,12 @@ export function useAlbum(options: UseAlbumOptions) {
   const { id } = options;
 
   return reactiveApi(
-    useLazyAsyncData(`album-${id}`, () => new AlbumApi().albumIdGet({ id })),
+    useCachedLazyAsyncData(`album-${id}`, () => new AlbumApi().albumIdGet({ id })),
   );
 }
 
 export function useAlbums() {
   return reactiveApi(
-    useLazyAsyncData("albums", () => new AlbumApi().albumGet()),
+    useCachedLazyAsyncData("albums", () => new AlbumApi().albumGet()),
   );
 }

--- a/composables/browse.ts
+++ b/composables/browse.ts
@@ -2,13 +2,13 @@ import { AlbumApi, BrowseApi, FacetsApi } from "@bcc-code/bmm-sdk-fetch";
 
 export function useBrowse() {
   return reactiveApi(
-    useLazyAsyncData("browse", () => new BrowseApi().browseGet()),
+    useCachedLazyAsyncData("browse", () => new BrowseApi().browseGet()),
   );
 }
 
 export function useBrowseEvents(skip: number = 0) {
   return reactiveApi(
-    useLazyAsyncData("browse-events", () =>
+    useCachedLazyAsyncData("browse-events", () =>
       new BrowseApi().browseEventsGet({ skip }),
     ),
   );
@@ -16,7 +16,7 @@ export function useBrowseEvents(skip: number = 0) {
 
 export function useBrowseAudiobooks() {
   return reactiveApi(
-    useLazyAsyncData("browse-audiobooks", () =>
+    useCachedLazyAsyncData("browse-audiobooks", () =>
       new BrowseApi().browseAudiobooksGet(),
     ),
   );
@@ -24,13 +24,13 @@ export function useBrowseAudiobooks() {
 
 export function useBrowseMusic() {
   return reactiveApi(
-    useLazyAsyncData("browse-music", () => new BrowseApi().browseMusicGet()),
+    useCachedLazyAsyncData("browse-music", () => new BrowseApi().browseMusicGet()),
   );
 }
 
 export function useBrowsePodcast() {
   return reactiveApi(
-    useLazyAsyncData("browse-podcast", () =>
+    useCachedLazyAsyncData("browse-podcast", () =>
       new BrowseApi().browsePodcastsGet(),
     ),
   );
@@ -38,7 +38,7 @@ export function useBrowsePodcast() {
 
 export function useYearList() {
   return reactiveApi(
-    useLazyAsyncData("year-list", () =>
+    useCachedLazyAsyncData("year-list", () =>
       new FacetsApi().controllerAlbumPublishedYearsGet({
         controller: "facets",
       }),
@@ -48,7 +48,7 @@ export function useYearList() {
 
 export function useAlbumsInYear(year: number) {
   return reactiveApi(
-    useLazyAsyncData(`albums-in-year-${year}`, () =>
+    useCachedLazyAsyncData(`albums-in-year-${year}`, () =>
       new AlbumApi().albumPublishedYearGet({ year }),
     ),
   );

--- a/composables/cachedLazyAsyncData.ts
+++ b/composables/cachedLazyAsyncData.ts
@@ -1,0 +1,18 @@
+import type { AsyncDataOptions } from "#app";
+
+/**
+ * A thin wrapper around useLazyAsyncData that gets already fetched data, if available
+ * 
+ * @param key The cache key
+ * @param fn The async function fetching the data
+ * @param options Additional options
+ * @returns 
+ */
+export function useCachedLazyAsyncData<T>(key: string, fn: () => Promise<T>, options?: AsyncDataOptions<T, any>) {
+	return useLazyAsyncData(key, fn, {
+		getCachedData(k, nuxtApp) {
+			return nuxtApp.payload.data[k] ?? nuxtApp.static.data[k];
+		},
+		...options
+	});
+}

--- a/composables/contributor.ts
+++ b/composables/contributor.ts
@@ -7,7 +7,7 @@ interface UseContributorOptions {
 export function useContributor(options: UseContributorOptions) {
   const { id } = options;
 
-  return useLazyAsyncData(`contributor-${id}`, () =>
+  return useCachedLazyAsyncData(`contributor-${id}`, () =>
     new ContributorApi().contributorIdGet({ id }),
   );
 }
@@ -19,7 +19,7 @@ export function useContributorShuffle(id: number) {
 }
 
 export function useContributors() {
-  return useLazyAsyncData("contributors", () =>
+  return useCachedLazyAsyncData("contributors", () =>
     new ContributorApi().contributorGet(),
   );
 }

--- a/composables/discover.ts
+++ b/composables/discover.ts
@@ -3,7 +3,7 @@ import type { DiscoverGetRequest } from "@bcc-code/bmm-sdk-fetch";
 
 export function useDiscover(requestParameters: DiscoverGetRequest) {
   return reactiveApi(
-    useLazyAsyncData("discover", () =>
+    useCachedLazyAsyncData("discover", () =>
       new DiscoverApi().discoverGet(requestParameters),
     ),
   );

--- a/composables/playlist.ts
+++ b/composables/playlist.ts
@@ -8,7 +8,7 @@ export function useCuratedPlaylist(options: UseCuratedPlaylistOptions) {
   const { id } = options;
 
   return reactiveApi(
-    useLazyAsyncData(`playlist-${id}`, () =>
+    useCachedLazyAsyncData(`playlist-${id}`, () =>
       new PlaylistApi().playlistIdGet({ id }),
     ),
   );
@@ -24,7 +24,7 @@ export function useCuratedPlaylistTracks(
   const { id } = options;
 
   return reactiveApi(
-    useLazyAsyncData(`playlist-tracks-${id}`, () =>
+    useCachedLazyAsyncData(`playlist-tracks-${id}`, () =>
       new PlaylistApi().playlistIdTrackGet({ id }),
     ),
   );
@@ -32,13 +32,13 @@ export function useCuratedPlaylistTracks(
 
 export function useCuratedPlaylists() {
   return reactiveApi(
-    useLazyAsyncData("playlists", () => new PlaylistApi().playlistGet()),
+    useCachedLazyAsyncData("playlists", () => new PlaylistApi().playlistGet()),
   );
 }
 
 export function useFeaturedPlaylists() {
   return reactiveApi(
-    useLazyAsyncData("playlists-featured", () =>
+    useCachedLazyAsyncData("playlists-featured", () =>
       new PlaylistApi().playlistDocumentsGet(),
     ),
   );

--- a/composables/podcast.ts
+++ b/composables/podcast.ts
@@ -8,7 +8,7 @@ export function usePodcast(options: UsePodcastOptions) {
   const { id } = options;
 
   return reactiveApi(
-    useLazyAsyncData(`podcast-${id}`, () =>
+    useCachedLazyAsyncData(`podcast-${id}`, () =>
       new PodcastApi().podcastIdGet({ id }),
     ),
   );
@@ -22,7 +22,7 @@ export function usePodcastTracks(options: UsePodcastTracksOptions) {
   const { id } = options;
 
   return reactiveApi(
-    useLazyAsyncData(`podcast-tracks-${id}`, () =>
+    useCachedLazyAsyncData(`podcast-tracks-${id}`, () =>
       new PodcastApi().podcastIdTrackGet({ id }),
     ),
   );
@@ -30,7 +30,7 @@ export function usePodcastTracks(options: UsePodcastTracksOptions) {
 
 export function usePodcasts() {
   return reactiveApi(
-    useLazyAsyncData("podcasts", () => new PodcastApi().podcastGet()),
+    useCachedLazyAsyncData("podcasts", () => new PodcastApi().podcastGet()),
   );
 }
 

--- a/composables/privatePlaylists.ts
+++ b/composables/privatePlaylists.ts
@@ -13,7 +13,7 @@ export function usePrivatePlaylist(options: UseTrackCollectionOptions) {
   const { id } = options;
 
   return reactiveApi(
-    useLazyAsyncData(`track-collection-${id}`, () =>
+    useCachedLazyAsyncData(`track-collection-${id}`, () =>
       new TrackCollectionApi().trackCollectionIdGet({ id }),
     ),
   );
@@ -23,7 +23,7 @@ export function usePrivatePlaylists() {
   if (playlistsRequest != null) return playlistsRequest;
 
   playlistsRequest = reactiveApi(
-    useLazyAsyncData("track-collections", () =>
+    useCachedLazyAsyncData("track-collections", () =>
       new TrackCollectionApi().trackCollectionGet(),
     ),
   );
@@ -42,7 +42,7 @@ export function addPrivatePlaylist(name: string) {
 
 export function useSharedPrivatePlaylist(sharingSecret: string) {
   return reactiveApi(
-    useLazyAsyncData(`track-collection-shared-${sharingSecret}`, () =>
+    useCachedLazyAsyncData(`track-collection-shared-${sharingSecret}`, () =>
       new SharedPlaylistApi().sharedPlaylistSharingSecretGet({ sharingSecret }),
     ),
   );

--- a/composables/search.ts
+++ b/composables/search.ts
@@ -8,7 +8,7 @@ interface UseSearchOptions {
 export function useSearch(options: UseSearchOptions) {
   const { term, filter } = options;
   return reactiveApi(
-    useLazyAsyncData(`search-${term}-${filter}`, () =>
+    useCachedLazyAsyncData(`search-${term}-${filter}`, () =>
       new SearchApi().searchV2TermGet(options),
     ),
   );

--- a/composables/track.ts
+++ b/composables/track.ts
@@ -6,7 +6,7 @@ import { PublishedFilter, TrackApi } from "@bcc-code/bmm-sdk-fetch";
 
 export function useTracks(options: TrackGetRequest = {}) {
   return reactiveApi(
-    useLazyAsyncData("tracks", () => new TrackApi().trackGet(options)),
+    useCachedLazyAsyncData("tracks", () => new TrackApi().trackGet(options)),
   );
 }
 

--- a/composables/user.ts
+++ b/composables/user.ts
@@ -7,7 +7,10 @@ export function useCurrentUser(): AsyncData<UserModel, Error | null> {
   cachedComposable ??= useAsyncData(
     `current-user-asyncdata`,
     () => new CurrentUserApi().currentUserGet(),
-    { dedupe: "defer" },
+    {
+      dedupe: "defer",
+      getCachedData: (k, nuxtApp) => nuxtApp.payload.data[k] ?? nuxtApp.static.data[k]
+    },
   );
   return cachedComposable!;
 }


### PR DESCRIPTION
This pull request adds a quick and easy client-side caching solution using some of Nuxt's built-in functionality.

I've implemented a thin wrapper around `useLazyAsyncData` with an added `getCachedData` method. This method gets cached data from Nuxt's payload if the key already exists.

This solution is only per session though; it doesn't cache data for offline use.