### PR TITLE
[Media Player] Transition cover between open and closed states

### DIFF
--- a/components/media-player/MediaPlayer.vue
+++ b/components/media-player/MediaPlayer.vue
@@ -17,6 +17,16 @@ defineShortcuts({
   ctrl_arrowright: () => next(),
   ctrl_shift_arrowright: () => next(),
 });
+
+function setOpen(value: boolean) {
+  if ("startViewTransition" in document && document.startViewTransition) {
+    document.startViewTransition(() => {
+      open.value = value;
+    });
+  } else {
+    open.value = value;
+  }
+}
 </script>
 
 <template>
@@ -37,8 +47,13 @@ defineShortcuts({
         'animation-timing-function': 'cubic-bezier(0.19, 1, 0.22, 1)',
       }"
     >
-      <MediaPlayerClosed v-if="!open" @click.stop="open = !open" />
-      <MediaPlayerOpen v-else v-model="open" class="player-height" />
+      <MediaPlayerClosed v-if="!open" @click.stop="setOpen(!open)" />
+      <MediaPlayerOpen
+        v-else
+        :model-value="open"
+        @update:model-value="setOpen"
+        class="player-height"
+      />
     </div>
   </div>
 </template>

--- a/components/media-player/MediaPlayerClosed.vue
+++ b/components/media-player/MediaPlayerClosed.vue
@@ -29,6 +29,7 @@ const onPointerDownProgressBar = () => {
       <CoverImage
         :src="currentTrack?.meta?.attachedPicture"
         class="h-[48px] rounded-md"
+        :style="`view-transition-name: player-cover-${currentTrack?.id}`"
       />
       <div
         class="flex min-w-0 flex-1 flex-col gap-1 truncate whitespace-nowrap"

--- a/components/media-player/MediaPlayerOpen.vue
+++ b/components/media-player/MediaPlayerOpen.vue
@@ -58,6 +58,7 @@ useDraggable(queueListElement, queue, {
           <CoverImage
             :src="currentTrack?.meta?.attachedPicture"
             class="w-20 rounded-md x-tall:w-40"
+            :style="`view-transition-name: player-cover-${currentTrack?.id}`"
           />
         </div>
 


### PR DESCRIPTION
Adds a simple transition for the track cover in the media player using the [View Transition API](https://developer.mozilla.org/en-US/docs/Web/API/View_Transition_API) to visually connect the two states.
If a browser doesn't support it, it will simply work as before.

## Before

https://github.com/user-attachments/assets/56d225f3-e91b-4b35-8aed-286e874b1e0b

## After	

https://github.com/user-attachments/assets/bf8421c7-16f2-4234-836e-ce89336ca451
