### PR TITLE
fix: prevent stale data in TrackMenu by forcing remount on track change

### DIFF
--- a/components/media-player/MediaPlayerOpen.vue
+++ b/components/media-player/MediaPlayerOpen.vue
@@ -178,6 +178,7 @@ const trackCover = computed(() => coverForTrack(currentTrack.value));
         <div>
           <TrackMenu
             v-if="currentTrack"
+            :key="currentTrack.id"
             :track="currentTrack"
             origin="media-player"
             button-class="rounded-full border border-label-separator p-1.5"


### PR DESCRIPTION
Using :key on the whole menu prevents future similar issues and is a bit easier to manage, but I'd also recommend updating to a newer nuxt version where you can pass a reactive key to useLazyAsyncData (so you could do `useTrackTranscription(() => props.track.id)` instead)